### PR TITLE
데모 앱 Gesture 탭 추가 및 testID 있음/없음 둘 다 지원

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,10 @@
       "dependencies": {
         "react": "^19.2.3",
         "react-native": "0.83.1",
+        "react-native-gesture-handler": "^2.30.0",
+        "react-native-reanimated": "4.2.1",
         "react-native-webview": "^13.16.0",
+        "react-native-worklets": "^0.7.0",
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -300,6 +303,8 @@
 
     "@babel/preset-modules": ["@babel/preset-modules@0.1.6-no-external-plugins", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@babel/types": "^7.4.4", "esutils": "^2.0.2" }, "peerDependencies": { "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0" } }, "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA=="],
 
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
@@ -313,6 +318,8 @@
     "@bunup/dts": ["@bunup/dts@0.14.50", "", { "dependencies": { "@babel/parser": "^7.28.6", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.16.2", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.10.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-EGQOLwdX5Am8z5CEPupGm7Hx/e+QTwhpnFSGolSJ4HdkjHjtMvLpdevbttnYpKzRZET4M7tDoH7hP1HwJKCl3A=="],
 
     "@bunup/shared": ["@bunup/shared@0.16.20", "", { "peerDependencies": { "typescript": "latest" }, "optionalPeers": ["typescript"] }, "sha512-2VyH6lF/jm30dYycRaUBYiejw/nGj8RGLuMxbQNpVK7ZlkobiQ7Vzzke2RYCfpHZZ07+/ZmqYw94nkdIeUh/sQ=="],
+
+    "@egjs/hammerjs": ["@egjs/hammerjs@2.0.17", "", { "dependencies": { "@types/hammerjs": "^2.0.36" } }, "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -615,6 +622,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
+
+    "@types/hammerjs": ["@types/hammerjs@2.0.46", "", {}, "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
@@ -1054,6 +1063,8 @@
 
     "hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
+    "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
     "hono": ["hono@4.11.8", "", {}, "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -1450,9 +1461,17 @@
 
     "react-native": ["react-native@0.83.1", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.83.1", "@react-native/codegen": "0.83.1", "@react-native/community-cli-plugin": "0.83.1", "@react-native/gradle-plugin": "0.83.1", "@react-native/js-polyfills": "0.83.1", "@react-native/normalize-colors": "0.83.1", "@react-native/virtualized-lists": "0.83.1", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.32.0", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "hermes-compiler": "0.14.0", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.3", "metro-source-map": "^0.83.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.1", "react": "^19.2.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-mL1q5HPq5cWseVhWRLl+Fwvi5z1UO+3vGOpjr+sHFwcUletPRZ5Kv+d0tUfqHmvi73/53NjlQqX1Pyn4GguUfA=="],
 
+    "react-native-gesture-handler": ["react-native-gesture-handler@2.30.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA=="],
+
+    "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.2.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q=="],
+
     "react-native-mcp-demo-app": ["react-native-mcp-demo-app@workspace:examples/demo-app"],
 
+    "react-native-reanimated": ["react-native-reanimated@4.2.1", "", { "dependencies": { "react-native-is-edge-to-edge": "1.2.1", "semver": "7.7.3" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-worklets": ">=0.7.0" } }, "sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg=="],
+
     "react-native-webview": ["react-native-webview@13.16.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "invariant": "2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA=="],
+
+    "react-native-worklets": ["react-native-worklets@0.7.3", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "7.27.1", "@babel/plugin-transform-class-properties": "7.27.1", "@babel/plugin-transform-classes": "7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1", "@babel/plugin-transform-optional-chaining": "7.27.1", "@babel/plugin-transform-shorthand-properties": "7.27.1", "@babel/plugin-transform-template-literals": "7.27.1", "@babel/plugin-transform-unicode-regex": "7.27.1", "@babel/preset-typescript": "7.27.1", "convert-source-map": "2.0.0", "semver": "7.7.3" }, "peerDependencies": { "@babel/core": "*", "react": "*", "react-native": "*" } }, "sha512-m/CIUCHvLQulboBn0BtgpsesXjOTeubU7t+V0lCPpBj0t2ExigwqDHoKj3ck7OeErnjgkD27wdAtQCubYATe3g=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -1808,6 +1827,8 @@
 
     "finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
+    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -1829,6 +1850,18 @@
     "react-native/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "react-native/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "react-native-reanimated/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "react-native-worklets/@babel/plugin-transform-class-properties": ["@babel/plugin-transform-class-properties@7.27.1", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA=="],
+
+    "react-native-worklets/@babel/plugin-transform-classes": ["@babel/plugin-transform-classes@7.28.4", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-globals": "^7.28.0", "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-replace-supers": "^7.27.1", "@babel/traverse": "^7.28.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA=="],
+
+    "react-native-worklets/@babel/plugin-transform-nullish-coalescing-operator": ["@babel/plugin-transform-nullish-coalescing-operator@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA=="],
+
+    "react-native-worklets/@babel/plugin-transform-optional-chaining": ["@babel/plugin-transform-optional-chaining@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg=="],
+
+    "react-native-worklets/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/examples/demo-app/android/gradle.properties
+++ b/examples/demo-app/android/gradle.properties
@@ -4,7 +4,8 @@ android.useAndroidX=true
 reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # Metro 번들러 포트 (기본 8081 → 8230)
 reactNativeDevServerPort=8230
-newArchEnabled=true
+# RNGH 2.3.0는 RN 0.83 New Arch Gradle 구조에서 :ReactAndroid를 찾지 못함. 데모용으로 Old Arch 사용.
+newArchEnabled=false
 hermesEnabled=true
 edgeToEdgeEnabled=false
 usesCleartextTraffic=true

--- a/examples/demo-app/babel.config.js
+++ b/examples/demo-app/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset', '@ohah/react-native-mcp-server/babel-preset'],
+  plugins: ['react-native-worklets/plugin'],
 };

--- a/examples/demo-app/ios/Podfile.lock
+++ b/examples/demo-app/ios/Podfile.lock
@@ -2477,6 +2477,215 @@ PODS:
     - React-perflogger (= 0.83.1)
     - React-utils (= 0.83.1)
     - SocketRocket
+  - RNGestureHandler (2.30.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - RNReanimated (4.2.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/reanimated (= 4.2.1)
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNReanimated/reanimated (4.2.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/reanimated/apple (= 4.2.1)
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNReanimated/reanimated/apple (4.2.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNWorklets (0.7.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets/worklets (= 0.7.3)
+    - SocketRocket
+    - Yoga
+  - RNWorklets/worklets (0.7.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets/worklets/apple (= 0.7.3)
+    - SocketRocket
+    - Yoga
+  - RNWorklets/worklets/apple (0.7.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2559,6 +2768,9 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios/ReactAppDependencyProvider`)
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReanimated (from `../node_modules/react-native-reanimated`)
+  - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -2722,6 +2934,12 @@ EXTERNAL SOURCES:
     :path: build/generated/ios/ReactCodegen
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
+  RNReanimated:
+    :path: "../node_modules/react-native-reanimated"
+  RNWorklets:
+    :path: "../node_modules/react-native-worklets"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -2803,6 +3021,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
   ReactCodegen: 3be49a618bfb52942134a2192a34017ec587ee4f
   ReactCommon: 05ad684db7d88e194272ae26baddf6300e30b8b7
+  RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
+  RNReanimated: b38fd8f0edd62c58096d467792def4a35d51aba4
+  RNWorklets: ab3a15142fa60fef4cfe6ec42616e99ae29f5c99
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 5bd0956bf9cb16f75101e78b5e852c7577bc5a45
 

--- a/examples/demo-app/package.json
+++ b/examples/demo-app/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "react": "^19.2.3",
     "react-native": "0.83.1",
-    "react-native-webview": "^13.16.0"
+    "react-native-gesture-handler": "^2.30.0",
+    "react-native-reanimated": "4.2.1",
+    "react-native-webview": "^13.16.0",
+    "react-native-worklets": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/examples/demo-app/src/App.tsx
+++ b/examples/demo-app/src/App.tsx
@@ -1,17 +1,19 @@
 /**
  * React Native MCP 데모 앱
- * 하단 탭: Scroll / Press / Input / FlatList / WebView / Network
+ * 하단 탭: Scroll / Press / Input / FlatList / WebView / Network / Gesture
  * @format
  */
 
 import React from 'react';
 import { StyleSheet, View, useColorScheme, StatusBar } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ScrollViewScreen } from './screens/ScrollViewScreen';
 import { PressScreen } from './screens/PressScreen';
 import { InputScreen } from './screens/InputScreen';
 import { FlatListScreen } from './screens/FlatListScreen';
 import { WebViewScreen } from './screens/WebViewScreen';
 import { NetworkScreen } from './screens/NetworkScreen';
+import { GestureScreen } from './screens/GestureScreen';
 import { TabBar, type TabId } from './components/TabBar';
 
 function App(): React.JSX.Element {
@@ -19,22 +21,26 @@ function App(): React.JSX.Element {
   const [activeTab, setActiveTab] = React.useState<TabId>('scroll');
 
   return (
-    <View style={[styles.container, isDarkMode && styles.containerDark]}>
-      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <View style={styles.content}>
-        {activeTab === 'scroll' && <ScrollViewScreen isDarkMode={isDarkMode} />}
-        {activeTab === 'press' && <PressScreen isDarkMode={isDarkMode} />}
-        {activeTab === 'input' && <InputScreen isDarkMode={isDarkMode} />}
-        {activeTab === 'list' && <FlatListScreen isDarkMode={isDarkMode} />}
-        {activeTab === 'webview' && <WebViewScreen isDarkMode={isDarkMode} />}
-        {activeTab === 'network' && <NetworkScreen isDarkMode={isDarkMode} />}
+    <GestureHandlerRootView style={styles.root}>
+      <View style={[styles.container, isDarkMode && styles.containerDark]}>
+        <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+        <View style={styles.content}>
+          {activeTab === 'scroll' && <ScrollViewScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'press' && <PressScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'input' && <InputScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'list' && <FlatListScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'webview' && <WebViewScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'network' && <NetworkScreen isDarkMode={isDarkMode} />}
+          {activeTab === 'gesture' && <GestureScreen isDarkMode={isDarkMode} />}
+        </View>
+        <TabBar activeTab={activeTab} onTabChange={setActiveTab} isDarkMode={isDarkMode} />
       </View>
-      <TabBar activeTab={activeTab} onTabChange={setActiveTab} isDarkMode={isDarkMode} />
-    </View>
+    </GestureHandlerRootView>
   );
 }
 
 const styles = StyleSheet.create({
+  root: { flex: 1 },
   container: { flex: 1, backgroundColor: '#fff' },
   containerDark: { backgroundColor: '#1a1a1a' },
   content: { flex: 1 },

--- a/examples/demo-app/src/components/TabBar.tsx
+++ b/examples/demo-app/src/components/TabBar.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { StyleSheet, Text, View, Pressable } from 'react-native';
 
-export type TabId = 'scroll' | 'press' | 'input' | 'list' | 'webview' | 'network';
+export type TabId = 'scroll' | 'press' | 'input' | 'list' | 'webview' | 'network' | 'gesture';
 
 const tabs: { id: TabId; label: string; testID: string }[] = [
   { id: 'scroll', label: 'Scroll', testID: 'tab-scroll' },
@@ -14,6 +14,7 @@ const tabs: { id: TabId; label: string; testID: string }[] = [
   { id: 'list', label: 'List', testID: 'tab-list' },
   { id: 'webview', label: 'WebView', testID: 'tab-webview' },
   { id: 'network', label: 'Network', testID: 'tab-network' },
+  { id: 'gesture', label: 'Gesture', testID: 'tab-gesture' },
 ];
 
 export type TabBarProps = {

--- a/examples/demo-app/src/screens/GestureScreen.tsx
+++ b/examples/demo-app/src/screens/GestureScreen.tsx
@@ -1,0 +1,171 @@
+/**
+ * Gesture 탭 — react-native-gesture-handler + react-native-reanimated 예제
+ * MCP: testID 있음 → click(uid), testID 없음 → click_by_label 로 각각 탭 가능
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { TouchableOpacity as GHTouchableOpacity } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+
+export type GestureScreenProps = {
+  isDarkMode: boolean;
+};
+
+export function GestureScreen({ isDarkMode }: GestureScreenProps) {
+  const [ghTaps, setGhTaps] = React.useState(0);
+  const [ghTapsNoId, setGhTapsNoId] = React.useState(0);
+  const [reanimatedTaps, setReanimatedTaps] = React.useState(0);
+  const [reanimatedTapsNoId, setReanimatedTapsNoId] = React.useState(0);
+  const scale = useSharedValue(1);
+  const scaleNoId = useSharedValue(1);
+
+  const animatedBoxStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+  const animatedBoxStyleNoId = useAnimatedStyle(() => ({
+    transform: [{ scale: scaleNoId.value }],
+  }));
+
+  const onReanimatedPressIn = () => {
+    scale.value = withSpring(0.9, { damping: 15, stiffness: 200 });
+  };
+  const onReanimatedPressOut = () => {
+    scale.value = withSpring(1);
+  };
+  const onReanimatedPressInNoId = () => {
+    scaleNoId.value = withSpring(0.9, { damping: 15, stiffness: 200 });
+  };
+  const onReanimatedPressOutNoId = () => {
+    scaleNoId.value = withSpring(1);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, isDarkMode && styles.textDark]}>Gesture</Text>
+      <Text style={[styles.subtitle, isDarkMode && styles.textDark]}>
+        react-native-gesture-handler + react-native-reanimated
+      </Text>
+
+      {/* testID 있음 — MCP click(uid) */}
+      <Text style={[styles.sectionTitle, isDarkMode && styles.textDark]}>
+        GestureHandler TouchableOpacity (testID 있음)
+      </Text>
+      <GHTouchableOpacity
+        style={styles.ghButton}
+        onPress={() => setGhTaps((n) => n + 1)}
+        testID="gesture-gh-pressable"
+        activeOpacity={0.8}
+      >
+        <Text style={styles.ghButtonText}>RNGH TouchableOpacity: {ghTaps}</Text>
+      </GHTouchableOpacity>
+
+      {/* testID 없음 — MCP click_by_label */}
+      <Text style={[styles.sectionTitle, isDarkMode && styles.textDark]}>
+        GestureHandler TouchableOpacity (라벨만)
+      </Text>
+      <GHTouchableOpacity
+        style={[styles.ghButton, styles.ghButtonSecondary]}
+        onPress={() => setGhTapsNoId((n) => n + 1)}
+        activeOpacity={0.8}
+      >
+        <Text style={styles.ghButtonTextSecondary}>RNGH 라벨만: {ghTapsNoId}</Text>
+      </GHTouchableOpacity>
+
+      {/* Reanimated: testID 있음 */}
+      <Text style={[styles.sectionTitle, isDarkMode && styles.textDark]}>
+        Reanimated 스케일 (testID 있음)
+      </Text>
+      <Animated.View style={[styles.animatedBox, animatedBoxStyle]} testID="gesture-reanimated-box">
+        <GHTouchableOpacity
+          style={styles.animatedBoxInner}
+          onPressIn={onReanimatedPressIn}
+          onPressOut={onReanimatedPressOut}
+          onPress={() => setReanimatedTaps((n) => n + 1)}
+          testID="gesture-reanimated-trigger"
+          activeOpacity={1}
+        >
+          <Text style={styles.animatedBoxText}>눌러보세요</Text>
+          <Text style={styles.animatedBoxText}>{reanimatedTaps}</Text>
+        </GHTouchableOpacity>
+      </Animated.View>
+
+      {/* Reanimated: testID 없음 — click_by_label "눌러보세요 (라벨만)" */}
+      <Text style={[styles.sectionTitle, isDarkMode && styles.textDark]}>
+        Reanimated 스케일 (라벨만)
+      </Text>
+      <Animated.View style={[styles.animatedBox, animatedBoxStyleNoId]}>
+        <GHTouchableOpacity
+          style={[styles.animatedBoxInner, styles.animatedBoxInnerSecondary]}
+          onPressIn={onReanimatedPressInNoId}
+          onPressOut={onReanimatedPressOutNoId}
+          onPress={() => setReanimatedTapsNoId((n) => n + 1)}
+          activeOpacity={1}
+        >
+          <Text style={styles.animatedBoxText}>눌러보세요 (라벨만)</Text>
+          <Text style={styles.animatedBoxText}>{reanimatedTapsNoId}</Text>
+        </GHTouchableOpacity>
+      </Animated.View>
+
+      {/* Reanimated ScrollView */}
+      <Text style={[styles.sectionTitle, isDarkMode && styles.textDark]}>
+        Reanimated ScrollView
+      </Text>
+      <Animated.ScrollView
+        style={styles.reanimatedScroll}
+        contentContainerStyle={styles.reanimatedScrollContent}
+        testID="gesture-reanimated-scroll"
+      >
+        {[1, 2, 3, 4, 5].map((i) => (
+          <View key={i} style={styles.reanimatedScrollItem}>
+            <Text style={[styles.reanimatedScrollText, isDarkMode && styles.textDark]}>
+              Reanimated 목록 아이템 {i}
+            </Text>
+          </View>
+        ))}
+      </Animated.ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 24, paddingTop: 16 },
+  title: { fontSize: 22, fontWeight: '700', marginBottom: 4, color: '#000' },
+  textDark: { color: '#fff' },
+  subtitle: { fontSize: 13, marginBottom: 12, color: '#333' },
+  sectionTitle: { fontSize: 13, fontWeight: '600', marginBottom: 6, color: '#333' },
+  ghButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: '#0066cc',
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  ghButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  ghButtonSecondary: { backgroundColor: '#663399' },
+  ghButtonTextSecondary: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  animatedBox: {
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  animatedBoxInner: {
+    width: 120,
+    height: 80,
+    backgroundColor: '#0a6',
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  animatedBoxText: { color: '#fff', fontWeight: '600' },
+  animatedBoxInnerSecondary: { backgroundColor: '#c96' },
+  reanimatedScroll: { flex: 1, minHeight: 0, maxHeight: 160 },
+  reanimatedScrollContent: { paddingVertical: 8, paddingBottom: 24 },
+  reanimatedScrollItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#e8f4fc',
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  reanimatedScrollText: { fontSize: 14, color: '#333' },
+});


### PR DESCRIPTION
# Gesture 탭 추가 및 testID 있음/없음 둘 다 지원

## 제목(목적)

데모 앱에 Gesture 탭을 추가하고, MCP 도구 검증을 위해 testID가 있는 요소와 없는 요소를 둘 다 제공한다.

## 작업 내용

- **데모 앱**: GestureScreen을 추가했다. react-native-gesture-handler·react-native-reanimated 예제로, RNGH TouchableOpacity 버튼·Reanimated 스케일 박스·Reanimated ScrollView를 둔다. App·TabBar에 Gesture 탭을 연동했다.
- **testID 유무**: testID가 있는 버튼/박스(click(uid) 검증용)와 testID가 없는 버튼/박스(click_by_label 검증용)를 각각 두어, 두 방식 모두 데모에서 확인할 수 있게 했다. 탭 시 카운트가 올라가 시각적 변화를 볼 수 있다.
- **기타**: DESIGN.md·runtime-helpers 테스트·bun.lock·demo-app 의존성·android/ios 설정을 갱신했다.

Relates to #10
