### PR TITLE
Release 빌드에서 MCP 활성화 플래그 주입

### DIFF
--- a/packages/react-native-mcp-server/babel-plugin-app-registry.cjs
+++ b/packages/react-native-mcp-server/babel-plugin-app-registry.cjs
@@ -22,6 +22,7 @@ function babel_plugin_app_registry_default(babel) {
 					const programPath = path.findParent((p) => p.isProgram?.());
 					if (programPath?.node?.body) {
 						programPath.node.body.unshift(t.expressionStatement(t.callExpression(t.identifier("require"), [t.stringLiteral(RUNTIME_MODULE_ID)])));
+						programPath.node.body.unshift(t.expressionStatement(t.assignmentExpression("=", t.memberExpression(t.identifier("global"), t.identifier("__REACT_NATIVE_MCP_ENABLED__")), t.booleanLiteral(true))));
 						state.runtimeInjected = true;
 					}
 				}

--- a/packages/react-native-mcp-server/src/__tests__/babel-plugins.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/babel-plugins.test.ts
@@ -28,6 +28,8 @@ AppRegistry.registerComponent('App', () => App);`;
     expect(result?.code).toContain('__REACT_NATIVE_MCP__.registerComponent');
     expect(result?.code).toContain('@ohah/react-native-mcp-server/runtime');
     expect(result?.code).not.toContain('AppRegistry.registerComponent');
+    // Release 빌드에서도 런타임 연결되도록 global 플래그 주입 확인
+    expect(result?.code).toContain('global.__REACT_NATIVE_MCP_ENABLED__ = true');
   });
 
   it('플러그인으로 실행 시 node_modules 경로면 변환하지 않는다', () => {

--- a/packages/react-native-mcp-server/src/babel-plugin-app-registry.ts
+++ b/packages/react-native-mcp-server/src/babel-plugin-app-registry.ts
@@ -46,9 +46,23 @@ export default function (babel: BabelApi): { name: string; visitor: Record<strin
             | NodePath<t.Program>
             | undefined;
           if (programPath?.node?.body) {
+            // 1) MCP 런타임 require
             programPath.node.body.unshift(
               t.expressionStatement(
                 t.callExpression(t.identifier('require'), [t.stringLiteral(RUNTIME_MODULE_ID)])
+              )
+            );
+            // 2) Release 빌드에서도 런타임이 WebSocket 연결하도록 global 플래그 주입
+            programPath.node.body.unshift(
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.memberExpression(
+                    t.identifier('global'),
+                    t.identifier('__REACT_NATIVE_MCP_ENABLED__')
+                  ),
+                  t.booleanLiteral(true)
+                )
               )
             );
             state.runtimeInjected = true;


### PR DESCRIPTION
# Release 빌드에서 MCP 활성화 플래그 주입

## 목적

Babel 플러그인에서 `global.__REACT_NATIVE_MCP_ENABLED__ = true`를 주입하여, Release 빌드에서도 MCP WebSocket 연결이 동작하도록 한다.

## 작업 내용

- **babel-plugin-app-registry**: 엔트리 번들 상단에 `global.__REACT_NATIVE_MCP_ENABLED__ = true` 할당문을 추가했다. 기존 MCP 런타임 require 주입과 함께, Release 빌드에서 런타임이 WebSocket을 연결하도록 플래그를 넣었다.
- **테스트**: Babel 플러그인 테스트에 해당 플래그 주입 검증을 추가했다.
