### PR TITLE
docs: 모노레포 문서에서 document를 Rspress로 수정

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -19,7 +19,7 @@
 | `packages/react-native-mcp-test`   | YAML 기반 E2E 테스트 러너                       | ❌                                 |
 | `editor/vscode`                    | VS Code 확장 (React Native MCP DevTools)        | 마켓플레이스/vsix                  |
 | `examples/demo-app`                | 데모 앱 (E2E 테스트 대상)                       | ❌                                 |
-| `document`                         | Docusaurus 문서 사이트                          | ❌                                 |
+| `document`                         | Rspress 문서 사이트                             | ❌                                 |
 
 ## 배포 (관리자)
 


### PR DESCRIPTION
# 모노레포 문서 document 설명 수정

## 목적

docs/monorepo.md의 디렉터리 구조 표에서 `document` 항목 설명이 실제 사용 중인 도구와 다르게 되어 있어, Rspress로 수정한다.

## 작업 내용

- **docs/monorepo.md**: `document` 행의 설명을 "Docusaurus 문서 사이트"에서 "Rspress 문서 사이트"로 변경했다. document 워크스페이스는 package.json에서 rspress를 사용하고 있으므로 표기가 맞도록 고쳤다.
