### PR TITLE
fix(docs): Rspress 문서 빌드 시 rspress/theme import 오류 수정

### DIFF
--- a/document/docs/en/mcp/getting-started.mdx
+++ b/document/docs/en/mcp/getting-started.mdx
@@ -31,7 +31,7 @@ This auto-detects your project (React Native version, Expo, package manager) and
 
 ## Step 2: Run the app
 
-import { Tab, Tabs } from 'rspress/theme';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 <Tabs>
   <Tab label="Bare RN">

--- a/document/docs/ko/mcp/getting-started.mdx
+++ b/document/docs/ko/mcp/getting-started.mdx
@@ -31,7 +31,7 @@ npx -y @ohah/react-native-mcp-server init
 
 ## Step 2: 앱 실행
 
-import { Tab, Tabs } from 'rspress/theme';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 <Tabs>
   <Tab label="Bare RN">


### PR DESCRIPTION
# fix(docs): Rspress 문서 빌드 시 rspress/theme import 오류 수정

## 제목(목적)

Rspress v2 환경에서 `bun run docs:build`가 실패하는 원인을 제거하고, CI 문서 빌드를 통과시키기 위함이다.

## 작업 내용

getting-started.mdx(영문·한글)에서 Tab/Tabs 컴포넌트를 불러올 때 사용하던 `rspress/theme`는 Rspress v2에서 더 이상 해석되지 않아 "Module not found: Can't resolve 'rspress/theme'" 오류가 발생했다. Rspress v2 문서에 따라 docs 디렉터리에서는 `@rspress/core/theme`를 사용해야 하므로, 두 파일의 import를 `import { Tab, Tabs } from '@rspress/core/theme';`로 통일했다. index.mdx는 이미 동일 경로를 사용 중이었고, 이번 수정으로 문서 빌드가 성공적으로 완료된다.
