### PR TITLE
docs: Expo·설계 문서에서 enable() 호출 안내 제거

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -205,7 +205,7 @@ Source Code
   ↓
 Bundle (Babel 변환 포함, runtime 포함)
   ↓
-App 실행 → __DEV__=false → WebSocket 미연결 (REACT_NATIVE_MCP_ENABLED로 Metro 실행 시 또는 MCP.enable() 수동 활성화)
+App 실행 → __DEV__=false → WebSocket 미연결 (REACT_NATIVE_MCP_ENABLED로 Metro 실행 시 연결, 앱 코드 불필요)
 ```
 
 ---
@@ -367,7 +367,7 @@ function MyButton({ title, onPress }) {
 8. **WebView**: `registerWebView`, `unregisterWebView`, `evaluateInWebView` (Babel 주입 필수 — Fiber 대체 불가)
 9. **콘솔 로그 캡처**: `nativeLoggingHook` 체이닝으로 콘솔 출력 버퍼링 (최대 500개). `getConsoleLogs(options)` / `clearConsoleLogs()`. level 맵핑: 0=log, 1=info, 2=warn, 3=error
 10. **네트워크 요청 캡처**: `XMLHttpRequest.prototype` + `fetch` monkey-patch로 네트워크 요청 버퍼링 (최대 200개, body 최대 10000자). `getNetworkRequests(options)` / `clearNetworkRequests()`. 필터: url(substring), method(정확), status(정확), since(timestamp), limit(기본 50)
-11. **WebSocket 연결**: `__DEV__` 자동 연결, Release는 `REACT_NATIVE_MCP_ENABLED`(빌드 시) 또는 `MCP.enable()` 수동 활성화, 지수 백오프 재연결 (최대 30초)
+11. **WebSocket 연결**: `__DEV__` 자동 연결, Release는 Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행해 transformer가 플래그 주입(앱 코드 불필요), 지수 백오프 재연결 (최대 30초)
 
 > runtime.js의 레거시 함수(registerPressHandler, registerScrollRef 등)는 코드가 유지되어 있으나,
 > Babel 플래그 비활성화로 호출되지 않음. Babel 플래그 재활성화 시 즉시 동작.
@@ -377,7 +377,7 @@ function MyButton({ title, onPress }) {
 **WebSocket 연결 조건**:
 
 - `__DEV__ === true` → 자동 연결
-- `__DEV__ === false` → Metro 실행 시 `REACT_NATIVE_MCP_ENABLED=true` 로 주입된 플래그 또는 `MCP.enable()` 호출 시 수동 연결
+- `__DEV__ === false` → Metro 실행 시 `REACT_NATIVE_MCP_ENABLED=true` 로 주입된 플래그로 연결 (앱에서 enable() 호출 불필요)
 - `runApplication` 시점에 미연결이면 재시도
 - 5초 주기 재시도 (MCP 서버가 나중에 뜨는 경우 대응)
 
@@ -466,7 +466,7 @@ function MyButton({ title, onPress }) {
   - [ ] 추적 코드 삽입 (미구현)
 - [x] 프로덕션 처리
   - [x] Babel 변환은 항상 적용 (testID, ref, onPress 래핑)
-  - [x] runtime은 `__DEV__` 체크 → false이면 WebSocket 미연결 (`REACT_NATIVE_MCP_ENABLED` 또는 `MCP.enable()`으로 활성화)
+  - [x] runtime은 `__DEV__` 체크 → false이면 WebSocket 미연결 (Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행해 활성화, 앱 코드 불필요)
   - [ ] Dead code elimination 검증 (미검증)
 - [x] MCP 조작 (evaluate_script로 구현)
   - [x] testID로 onPress 트리거 → 네이티브 `tap` 도구로 대체 (실제 터치 파이프라인)
@@ -637,7 +637,7 @@ const INJECT_SCROLL_REF = true; // false → true
 ### Phase 3
 
 - [x] AI가 버튼 클릭 등 조작 (네이티브 tap 도구로 실제 터치 주입)
-- [x] 프로덕션 빌드에서 WebSocket 미연결 (`__DEV__` 체크, `REACT_NATIVE_MCP_ENABLED` 또는 `MCP.enable()` 활성화)
+- [x] 프로덕션 빌드에서 WebSocket 미연결 (`__DEV__` 체크, Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행해 활성화)
 - [ ] Dead code elimination 검증
 
 ### Phase 4

--- a/docs/expo-guide.md
+++ b/docs/expo-guide.md
@@ -64,43 +64,17 @@ module.exports = function (api) {
 };
 ```
 
-### 3. MCP 런타임 활성화
+### 3. MCP 런타임 활성화 (앱 코드 불필요)
 
-프로젝트 구조에 따라 진입점이 다르다.
+Babel 프리셋만 적용하면 MCP 런타임이 자동으로 로드된다. **앱 진입점에 `enable()` 호출을 넣을 필요가 없다.**
 
-#### Expo Router 프로젝트 (`app/` 디렉토리)
+- **개발 빌드(`__DEV__`)**: Metro로 실행 시 자동으로 포트 12300에 연결된다.
+- **릴리즈/비개발 빌드**: Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행하면 transformer가 활성화 플래그를 주입해 연결된다.
 
-`app/_layout.tsx`에서 활성화:
-
-```tsx
-// app/_layout.tsx
-import { Stack } from 'expo-router';
-
-if (__DEV__) {
-  // @ts-ignore — babel-plugin-app-registry가 전역에 주입
-  global.__REACT_NATIVE_MCP__?.enable();
-}
-
-export default function RootLayout() {
-  return <Stack />;
-}
+```bash
+# 예: 릴리즈에서 MCP 사용 시
+REACT_NATIVE_MCP_ENABLED=true npx expo start --dev-client
 ```
-
-#### 기존 구조 (`App.tsx` / `index.js`)
-
-`index.js` 또는 `App.tsx` 상단에서 활성화:
-
-```js
-// index.js (또는 App.tsx)
-import { registerRootComponent } from 'expo';
-import App from './App';
-
-global.__REACT_NATIVE_MCP__?.enable();
-
-registerRootComponent(App);
-```
-
-> `__REACT_NATIVE_MCP__`는 Babel 프리셋이 주입하는 전역 객체다. 프리셋 없이는 `undefined`이므로 옵셔널 체이닝(`?.`)으로 안전하게 호출한다.
 
 ### 4. MCP 서버 설정
 
@@ -158,7 +132,7 @@ npx expo start --dev-client
 ### MCP 연결이 안 될 때
 
 1. MCP 서버가 실행 중인지 확인 (포트 12300)
-2. `__REACT_NATIVE_MCP__?.enable()` 호출이 되는지 확인 — `console.log(typeof __REACT_NATIVE_MCP__)` 로 체크
+2. 런타임 로드 여부 확인 — `console.log(typeof __REACT_NATIVE_MCP__)` 로 체크 (개발 빌드는 자동, 릴리즈는 Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행)
 3. Babel 프리셋이 적용되었는지 확인 — Metro 캐시 초기화 후 재시작:
    ```bash
    npx expo start --clear

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -60,12 +60,12 @@ E2E 기능을 Detox/Maestro 수준으로 맞추는 것보다, **fiber 접근 + M
 
 **해야 할 것**:
 
-| 항목                          | 설명                                                   |
-| ----------------------------- | ------------------------------------------------------ |
-| Expo Dev Client에서 동작 검증 | `npx expo start --dev-client` 환경에서 MCP 연결 테스트 |
-| Expo Go 확인                  | 샌드박스 환경에서 localhost WebSocket 연결 가능 여부   |
-| Expo Router 가이드            | `app/_layout.tsx`에서 `__DEV__` import 예시            |
-| `npx expo install` 호환 확인  | 패키지 설치 흐름 검증                                  |
+| 항목                          | 설명                                                                |
+| ----------------------------- | ------------------------------------------------------------------- |
+| Expo Dev Client에서 동작 검증 | `npx expo start --dev-client` 환경에서 MCP 연결 테스트              |
+| Expo Go 확인                  | 샌드박스 환경에서 localhost WebSocket 연결 가능 여부                |
+| Expo Router 가이드            | Babel 프리셋만으로 활성화, `app/_layout.tsx` 등 앱 코드 수정 불필요 |
+| `npx expo install` 호환 확인  | 패키지 설치 흐름 검증                                               |
 
 **난이도**: ★☆☆ — 코드 변경 없이 문서 + 검증 위주.
 

--- a/document/docs/en/mcp/expo-guide.md
+++ b/document/docs/en/mcp/expo-guide.md
@@ -64,43 +64,17 @@ module.exports = function (api) {
 };
 ```
 
-### 3. Enable the MCP runtime
+### 3. Enable the MCP runtime (no app code required)
 
-The entry point differs depending on your project structure.
+Once the Babel preset is applied, the MCP runtime loads automatically. **You do not need to call `enable()` in your app entry.**
 
-#### Expo Router projects (`app/` directory)
+- **Development (`__DEV__`)**: Connects to port 12300 automatically when running with Metro.
+- **Release/non-dev builds**: Run Metro with `REACT_NATIVE_MCP_ENABLED=true` so the transformer injects the enable flag.
 
-Enable in `app/_layout.tsx`:
-
-```tsx
-// app/_layout.tsx
-import { Stack } from 'expo-router';
-
-if (__DEV__) {
-  // @ts-ignore — injected globally by babel-preset
-  global.__REACT_NATIVE_MCP__?.enable();
-}
-
-export default function RootLayout() {
-  return <Stack />;
-}
+```bash
+# Example: using MCP in release
+REACT_NATIVE_MCP_ENABLED=true npx expo start --dev-client
 ```
-
-#### Traditional structure (`App.tsx` / `index.js`)
-
-Enable at the top of `index.js` or `App.tsx`:
-
-```js
-// index.js (or App.tsx)
-import { registerRootComponent } from 'expo';
-import App from './App';
-
-global.__REACT_NATIVE_MCP__?.enable();
-
-registerRootComponent(App);
-```
-
-> `__REACT_NATIVE_MCP__` is a global object injected by the Babel preset. Without the preset it's `undefined`, so use optional chaining (`?.`) for safe calls.
 
 ### 4. Configure the MCP server
 
@@ -158,7 +132,7 @@ npx expo start --dev-client
 ### MCP connection not working
 
 1. Check that the MCP server is running (port 12300)
-2. Verify `__REACT_NATIVE_MCP__?.enable()` is called — check with `console.log(typeof __REACT_NATIVE_MCP__)`
+2. Verify the runtime is loaded — e.g. `console.log(typeof __REACT_NATIVE_MCP__)` (dev builds connect automatically; for release, run Metro with `REACT_NATIVE_MCP_ENABLED=true`)
 3. Verify the Babel preset is applied — clear Metro cache and restart:
    ```bash
    npx expo start --clear

--- a/document/docs/ko/mcp/expo-guide.md
+++ b/document/docs/ko/mcp/expo-guide.md
@@ -64,43 +64,17 @@ module.exports = function (api) {
 };
 ```
 
-### 3. MCP 런타임 활성화
+### 3. MCP 런타임 활성화 (앱 코드 불필요)
 
-프로젝트 구조에 따라 진입점이 다릅니다.
+Babel 프리셋만 적용하면 MCP 런타임이 자동으로 로드됩니다. **앱 진입점에 `enable()` 호출을 넣을 필요가 없습니다.**
 
-#### Expo Router 프로젝트 (`app/` 디렉토리)
+- **개발 빌드(`__DEV__`)**: Metro로 실행 시 자동으로 포트 12300에 연결됩니다.
+- **릴리즈/비개발 빌드**: Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행하면 transformer가 활성화 플래그를 주입해 연결됩니다.
 
-`app/_layout.tsx`에서 활성화:
-
-```tsx
-// app/_layout.tsx
-import { Stack } from 'expo-router';
-
-if (__DEV__) {
-  // @ts-ignore — babel-preset이 전역에 주입
-  global.__REACT_NATIVE_MCP__?.enable();
-}
-
-export default function RootLayout() {
-  return <Stack />;
-}
+```bash
+# 예: 릴리즈에서 MCP 사용 시
+REACT_NATIVE_MCP_ENABLED=true npx expo start --dev-client
 ```
-
-#### 기존 구조 (`App.tsx` / `index.js`)
-
-`index.js` 또는 `App.tsx` 상단에서 활성화:
-
-```js
-// index.js (또는 App.tsx)
-import { registerRootComponent } from 'expo';
-import App from './App';
-
-global.__REACT_NATIVE_MCP__?.enable();
-
-registerRootComponent(App);
-```
-
-> `__REACT_NATIVE_MCP__`는 Babel 프리셋이 주입하는 전역 객체입니다. 프리셋 없이는 `undefined`이므로 옵셔널 체이닝(`?.`)으로 안전하게 호출합니다.
 
 ### 4. MCP 서버 설정
 
@@ -158,7 +132,7 @@ npx expo start --dev-client
 ### MCP 연결이 안 될 때
 
 1. MCP 서버가 실행 중인지 확인 (포트 12300)
-2. `__REACT_NATIVE_MCP__?.enable()` 호출이 되는지 확인 — `console.log(typeof __REACT_NATIVE_MCP__)` 로 체크
+2. 런타임 로드 여부 확인 — `console.log(typeof __REACT_NATIVE_MCP__)` 로 체크 (개발 빌드는 자동, 릴리즈는 Metro를 `REACT_NATIVE_MCP_ENABLED=true`로 실행)
 3. Babel 프리셋이 적용되었는지 확인 — Metro 캐시 초기화 후 재시작:
    ```bash
    npx expo start --clear

--- a/packages/react-native-mcp-server/runtime.js
+++ b/packages/react-native-mcp-server/runtime.js
@@ -2652,8 +2652,8 @@
 		PONG_TIMEOUT_MS = 1e4;
 		/**
 		* 릴리즈 빌드에서 MCP WebSocket 연결을 활성화한다.
-		* 기본은 빌드 시 REACT_NATIVE_MCP_ENABLED 로 활성화(transformer가 global 주입).
-		* 필요 시 앱에서 __REACT_NATIVE_MCP__.enable() 호출 가능.
+		* 권장: 빌드 시 REACT_NATIVE_MCP_ENABLED 로 Metro 실행(transformer가 global 주입). 앱 코드 불필요.
+		* 레거시: 앱에서 __REACT_NATIVE_MCP__.enable() 호출도 가능.
 		*/
 		MCP.enable = function() {
 			_mcpEnabled = true;

--- a/packages/react-native-mcp-server/src/runtime/connection.ts
+++ b/packages/react-native-mcp-server/src/runtime/connection.ts
@@ -1,6 +1,6 @@
 import { MCP } from './mcp-object';
 
-// ─── WebSocket 연결 (__DEV__ 자동 · 릴리즈는 REACT_NATIVE_MCP_ENABLED 또는 MCP.enable()) ─
+// ─── WebSocket 연결 (__DEV__ 자동 · 릴리즈는 REACT_NATIVE_MCP_ENABLED로 Metro 실행) ─
 
 var _isDevMode =
   (typeof globalThis !== 'undefined' &&
@@ -187,8 +187,8 @@ function connect(): void {
 
 /**
  * 릴리즈 빌드에서 MCP WebSocket 연결을 활성화한다.
- * 기본은 빌드 시 REACT_NATIVE_MCP_ENABLED 로 활성화(transformer가 global 주입).
- * 필요 시 앱에서 __REACT_NATIVE_MCP__.enable() 호출 가능.
+ * 권장: 빌드 시 REACT_NATIVE_MCP_ENABLED 로 Metro 실행(transformer가 global 주입). 앱 코드 불필요.
+ * 레거시: 앱에서 __REACT_NATIVE_MCP__.enable() 호출도 가능.
  */
 MCP.enable = function () {
   _mcpEnabled = true;


### PR DESCRIPTION
# docs: Expo·설계 문서에서 enable() 호출 안내 제거

## 제목(목적)

앱 진입점에서 `global.__REACT_NATIVE_MCP__?.enable()` 호출을 더 이상 사용하지 않는데, Expo 가이드와 설계 문서에 잘못 남아 있던 내용을 제거하고, Babel 프리셋과 Metro 환경변수만으로 활성화된다고 통일했습니다.

## 작업 내용

- **Expo 가이드** (document/docs/ko|en/mcp/expo-guide.md, docs/expo-guide.md): "3. MCP 런타임 활성화" 섹션에서 `app/_layout.tsx`·`index.js`에 넣는 `enable()` 호출 코드 예시를 삭제하고, "앱 코드 불필요, Babel 프리셋 + 개발 시 자동·릴리즈 시 REACT_NATIVE_MCP_ENABLED로 Metro 실행"만 안내하도록 수정했습니다. 트러블슈팅 문구도 "enable() 호출 확인" 대신 "런타임 로드 여부 확인"으로 바꿨습니다.
- **DESIGN.md**: WebSocket 연결 설명에서 "MCP.enable() 수동 활성화"를 제거하고, 릴리즈는 "Metro를 REACT_NATIVE_MCP_ENABLED=true로 실행해 transformer가 플래그 주입(앱 코드 불필요)"로 통일했습니다.
- **feature-roadmap.md**: Expo Router 가이드 설명을 "app/_layout.tsx에서 __DEV__ import 예시"에서 "Babel 프리셋만으로 활성화, 앱 코드 수정 불필요"로 수정했습니다.
- **connection.ts, runtime.js**: `MCP.enable` JSDoc을 "권장: REACT_NATIVE_MCP_ENABLED로 Metro 실행, 앱 코드 불필요 / 레거시: 앱에서 enable() 호출도 가능"으로 정리했습니다.

결과적으로 모든 문서와 주석에서 앱에서 `enable()`를 호출할 필요가 없고, Babel 프리셋과 Metro(필요 시 환경변수)만으로 MCP가 활성화된다는 설명으로 맞춰 두었습니다.
