### PR TITLE
feat: E2E 테스트 step 자동 재시도 옵션 (retryOnFail)

### DIFF
--- a/packages/react-native-mcp-server/src/test/cli.ts
+++ b/packages/react-native-mcp-server/src/test/cli.ts
@@ -22,6 +22,7 @@ const { values, positionals } = parseArgs({
     'no-bail': { type: 'boolean' },
     'no-auto-launch': { type: 'boolean' },
     'continue-on-error': { type: 'boolean' },
+    'retry-on-fail': { type: 'string' },
     help: { type: 'boolean', short: 'h' },
   },
 });
@@ -45,6 +46,7 @@ Options (run):
   --no-bail                      Continue running after suite failure
   --no-auto-launch               Do not launch app in create(); use setup launch step (e.g. CI install-only)
   --continue-on-error            Continue executing steps after a step failure (for diagnostics)
+  --retry-on-fail <N>            Auto-retry failed transient steps (tap, swipe, etc.) up to N times
 
 Options (report show):
   -o, --output <dir>             Directory containing dashboard/ (default: ./results)
@@ -129,6 +131,7 @@ async function runMain(target: string): Promise<void> {
     bail: !values['no-bail'],
     autoLaunch: !values['no-auto-launch'],
     continueOnError: values['continue-on-error'] ?? false,
+    retryOnFail: values['retry-on-fail'] ? Number(values['retry-on-fail']) : undefined,
     envVars: Object.keys(envVars).length > 0 ? envVars : undefined,
   });
 

--- a/packages/react-native-mcp-server/src/test/parser.ts
+++ b/packages/react-native-mcp-server/src/test/parser.ts
@@ -177,6 +177,7 @@ const suiteSchema = z.object({
     deviceId: z.string().optional(),
     orientation: z.number().optional(),
     continueOnError: z.boolean().optional(),
+    retryOnFail: z.number().int().min(0).optional(),
   }),
   setup: z.array(stepSchema).optional(),
   steps: z.array(stepSchema).min(1),

--- a/packages/react-native-mcp-server/src/test/runner.ts
+++ b/packages/react-native-mcp-server/src/test/runner.ts
@@ -17,6 +17,15 @@ function stepKey(step: TestStep): string {
   return Object.keys(step)[0]!;
 }
 
+/** transient step 타입 — 일시적 실패가 발생할 수 있어 자동 재시도 대상 */
+const RETRYABLE_STEP_TYPES = new Set([
+  'tap',
+  'swipe',
+  'doubleTap',
+  'longPress',
+  'scrollUntilVisible',
+]);
+
 function resolveBundleId(
   bundleId: TestSuite['config']['bundleId'],
   platform: Platform
@@ -312,12 +321,13 @@ async function runSteps(
   reporter: Reporter,
   suiteName: string,
   ctx: StepContext,
-  stepOpts?: { timeout?: number; continueOnError?: boolean }
+  stepOpts?: { timeout?: number; continueOnError?: boolean; retryOnFail?: number }
 ): Promise<{ results: StepResult[]; failed: boolean }> {
   const results: StepResult[] = [];
   let failed = false;
   const { outputDir } = ctx;
   const continueOnError = stepOpts?.continueOnError ?? false;
+  const retryOnFail = stepOpts?.retryOnFail ?? 0;
 
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i]!;
@@ -329,17 +339,35 @@ async function runSteps(
       continue;
     }
 
-    try {
-      await executeStep(app, step, ctx, stepOpts);
+    const maxAttempts =
+      retryOnFail > 0 && RETRYABLE_STEP_TYPES.has(stepKey(step)) ? retryOnFail + 1 : 1;
+    let lastErr: unknown;
+    let passed = false;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await executeStep(app, step, ctx, stepOpts);
+        passed = true;
+        break;
+      } catch (err) {
+        lastErr = err;
+        if (attempt < maxAttempts) {
+          console.log(`Step failed, retrying (attempt ${attempt + 1}/${maxAttempts})...`);
+          await new Promise((r) => setTimeout(r, 1_000));
+        }
+      }
+    }
+
+    if (passed) {
       const result: StepResult = { step, status: 'passed', duration: Date.now() - start };
       results.push(result);
       reporter.onStepResult(result);
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
+    } else {
+      const error = lastErr instanceof Error ? lastErr.message : String(lastErr);
       const failure = await captureFailure(app, suiteName, i, outputDir);
       const diffImagePath =
-        err && typeof err === 'object' && 'diffImagePath' in err
-          ? (err as { diffImagePath?: string }).diffImagePath
+        lastErr && typeof lastErr === 'object' && 'diffImagePath' in lastErr
+          ? (lastErr as { diffImagePath?: string }).diffImagePath
           : undefined;
       const result: StepResult = {
         step,
@@ -424,6 +452,7 @@ export async function runSuite(
 
   const connectionTimeout = opts.timeout ?? suite.config.timeout ?? 90_000;
   const continueOnError = opts.continueOnError ?? suite.config.continueOnError ?? false;
+  const retryOnFail = opts.retryOnFail ?? suite.config.retryOnFail ?? 0;
 
   try {
     // setup (setup은 항상 실패 시 중단 — continueOnError 적용하지 않음)
@@ -459,6 +488,7 @@ export async function runSuite(
         {
           timeout: connectionTimeout,
           continueOnError,
+          retryOnFail,
         }
       );
       allStepResults.push(...results);

--- a/packages/react-native-mcp-server/src/test/types.ts
+++ b/packages/react-native-mcp-server/src/test/types.ts
@@ -10,6 +10,8 @@ export interface TestConfig {
   orientation?: number;
   /** true면 step 실패 시에도 나머지 step을 계속 실행. 기본 false (실패 즉시 중단) */
   continueOnError?: boolean;
+  /** 실패한 transient step(tap, swipe, doubleTap, longPress, scrollUntilVisible)을 자동 재시도할 횟수. 기본 0 (재시도 안 함) */
+  retryOnFail?: number;
 }
 
 export interface TestSuite {
@@ -134,4 +136,6 @@ export interface RunOptions {
   envVars?: Record<string, string>;
   /** true면 step 실패 시에도 나머지 step을 계속 실행 (config.continueOnError 우선) */
   continueOnError?: boolean;
+  /** 실패한 transient step을 자동 재시도할 횟수. 기본 0 (재시도 안 함). config.retryOnFail 우선 */
+  retryOnFail?: number;
 }


### PR DESCRIPTION
## Summary
- transient step(tap, swipe, doubleTap, longPress, scrollUntilVisible) 실패 시 자동 재시도하는 `retryOnFail` 옵션 추가
- YAML `config.retryOnFail`, CLI `--retry-on-fail <N>`, `RunOptions.retryOnFail`로 설정 가능 (기본 0 = 재시도 안 함)
- assertion/wait 계열 step은 재시도 대상에서 제외하여 의미 없는 재시도 방지

## Test plan
- [x] `bun run build` 성공
- [x] `bun run test:unit` 528 tests 전체 통과
- [ ] YAML에 `retryOnFail: 2` 설정 후 tap step 실패 시 재시도 로그 확인
- [ ] CLI `--retry-on-fail 3` 옵션으로 동작 확인
- [ ] assertion step(assertVisible 등)은 재시도되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)