### PR TITLE
fix: CI E2E 간헐적 실패 안정화 — postMessage retry + 재시도 시 앱 재시작

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -227,10 +227,17 @@ jobs:
             adb shell wm size
             adb shell wm density
 
-            # E2E YAML 시나리오 실행 (시뮬/에뮬 지연 시 tap 타임아웃 확대, 실패 시 1회 재시도)
+            # E2E YAML 시나리오 실행 (시뮬/에뮬 지연 시 tap 타임아웃 확대, 실패 시 앱 재시작 후 1회 재시도)
             export REACT_NATIVE_MCP_TAP_TIMEOUT_MS=25000
             E2E_CMD="node packages/react-native-mcp-server/dist/test/cli.js run examples/demo-app/e2e/all-steps.yaml -p android -o e2e-artifacts/yaml-results --no-auto-launch"
-            $E2E_CMD || { echo "--- E2E 1차 실패, 재시도 ---"; sleep 5; $E2E_CMD; }
+            $E2E_CMD || {
+              echo "--- E2E 1차 실패, 앱 재시작 후 재시도 ---"
+              adb shell am force-stop com.reactnativemcp.demo 2>/dev/null || true
+              sleep 2
+              adb shell monkey -p com.reactnativemcp.demo -c android.intent.category.LAUNCHER 1 2>/dev/null || true
+              sleep 5
+              $E2E_CMD
+            }
 
       - name: 실패 시 스크린샷·로그 저장
         if: failure()

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -230,14 +230,7 @@ jobs:
             # E2E YAML 시나리오 실행 (시뮬/에뮬 지연 시 tap 타임아웃 확대, 실패 시 앱 재시작 후 1회 재시도)
             export REACT_NATIVE_MCP_TAP_TIMEOUT_MS=25000
             E2E_CMD="node packages/react-native-mcp-server/dist/test/cli.js run examples/demo-app/e2e/all-steps.yaml -p android -o e2e-artifacts/yaml-results --no-auto-launch"
-            $E2E_CMD || {
-              echo "--- E2E 1차 실패, 앱 재시작 후 재시도 ---"
-              adb shell am force-stop com.reactnativemcp.demo 2>/dev/null || true
-              sleep 2
-              adb shell monkey -p com.reactnativemcp.demo -c android.intent.category.LAUNCHER 1 2>/dev/null || true
-              sleep 5
-              $E2E_CMD
-            }
+            $E2E_CMD || (echo "--- E2E 1차 실패, 앱 재시작 후 재시도 ---" && adb shell am force-stop com.reactnativemcp.demo 2>/dev/null; sleep 2; adb shell monkey -p com.reactnativemcp.demo -c android.intent.category.LAUNCHER 1 2>/dev/null; sleep 5; $E2E_CMD)
 
       - name: 실패 시 스크린샷·로그 저장
         if: failure()

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -246,6 +246,12 @@ jobs:
         with:
           timeout_minutes: 15
           max_attempts: 2
+          on_retry_command: |
+            echo "--- 재시도 전 앱 재시작 ---"
+            xcrun simctl terminate booted org.reactnativemcp.demo 2>/dev/null || true
+            sleep 2
+            xcrun simctl launch booted org.reactnativemcp.demo 2>/dev/null || true
+            sleep 5
           command: node packages/react-native-mcp-server/dist/test/cli.js run examples/demo-app/e2e/all-steps.yaml -p ios -o e2e-artifacts/yaml-results --no-auto-launch
 
       - name: 실패 시 스크린샷·로그 저장

--- a/examples/demo-app/e2e/all-steps.yaml
+++ b/examples/demo-app/e2e/all-steps.yaml
@@ -127,11 +127,15 @@ steps:
   - tap: { selector: 'Pressable:text("다음")' }
   - waitForVisible: { selector: '#postmessage-count', timeout: 30000 }
   # ─── Step 14: WebView no testID (Babel이 자동 부여한 ID로 실행) ─────
-  - webviewEval:
-      webViewId: 'StepWebViewNoTestId-2-WebView'
-      script: 'document.getElementById("postmsg-btn").click()'
-  - wait: 2000
-  - waitForText: { text: 'postMessage 수: 1', selector: '#postmessage-count', timeout: 40000 }
+  # CI에서 postMessage 전달이 간헐적으로 느림 → retry로 안정화
+  - retry:
+      times: 2
+      steps:
+        - webviewEval:
+            webViewId: 'StepWebViewNoTestId-2-WebView'
+            script: 'document.getElementById("postmsg-btn").click()'
+        - wait: 3000
+        - waitForText: { text: 'postMessage 수: 1', selector: '#postmessage-count', timeout: 40000 }
   - tap: { selector: 'Pressable:text("다음")' }
   - waitForVisible: { selector: '#network-fetch-get', timeout: 30000 }
   # ─── Step 15: Network GET (android: 네트워크 불안정 → assertion 생략) ──


### PR DESCRIPTION
## Summary
CI E2E에서 반복적으로 실패하는 2가지 문제 수정:

### 1. postMessage WebView 테스트 (Step 14)
- `webviewEval` 후 `postMessage 수: 1` 텍스트가 40초 내에 안 나타남
- **수정**: `retry: { times: 2 }` 로 감싸고 wait 2s→3s 증가

### 2. retry 시 앱 상태 미초기화
- Attempt 1에서 Count:3까지 진행 후 실패 → Attempt 2에서 `Count: 0` 대기가 실패
- **수정**: iOS `on_retry_command`로 앱 terminate+relaunch, Android도 force-stop+monkey launch

## Test plan
- [ ] CI E2E iOS 통과
- [ ] CI E2E Android 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)