### PR TITLE
feat: rn-mcp CLI with Snapshot + Refs pattern

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -152,6 +152,13 @@ jobs:
           mkdir -p examples/demo-app/android/app/build/outputs/apk/release
           cp "${{ runner.temp }}/e2e-app-cache/android/app-release.apk" examples/demo-app/android/app/build/outputs/apk/release/
 
+      - name: Android SDK PATH 설정 및 adb 시작
+        run: |
+          echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
+          echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH
+          $ANDROID_HOME/platform-tools/adb start-server
+          $ANDROID_HOME/platform-tools/adb devices
+
       - name: AVD 캐시
         uses: actions/cache@v4
         id: avd-cache
@@ -173,6 +180,7 @@ jobs:
           heap-size: 2048M
           force-avd-creation: false
           emulator-options: -no-window -skin 1080x1920 -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -cores 4
+          emulator-boot-timeout: 600
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
@@ -188,6 +196,7 @@ jobs:
           heap-size: 2048M
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -skin 1080x1920 -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -cores 4
+          emulator-boot-timeout: 600
           disable-animations: true
           script: |
             echo "=== Connected Android devices (adb devices -l) ==="

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: 디스크 공간 확보
         run: |
-          sudo apt-get remove -y '^dotnet-.*' 'php.*' '^mongodb-.*' '^mysql-.*' azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y '^dotnet-.*' 'php.*' '^mongodb-.*' '^mysql-.*' azure-cli google-chrome-stable firefox powershell mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           sudo rm -rf /usr/share/dotnet/ /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -166,7 +166,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ steps.avd.outputs.name }}-1080x1920-ram4096-v3
+          key: avd-${{ steps.avd.outputs.name }}-1080x1920-ram4096-v4
 
       - name: AVD 스냅샷 생성 (캐시 미스 시)
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -232,6 +232,16 @@ jobs:
             E2E_CMD="node packages/react-native-mcp-server/dist/test/cli.js run examples/demo-app/e2e/all-steps.yaml -p android -o e2e-artifacts/yaml-results --no-auto-launch"
             $E2E_CMD || { echo "--- E2E 1차 실패, 재시도 ---"; sleep 5; $E2E_CMD; }
 
+            # CLI (rn-mcp) E2E smoke test
+            echo ""
+            echo "=== CLI (rn-mcp) E2E smoke test ==="
+            # YAML 테스트 후 앱 재시작
+            adb shell am force-stop com.reactnativemcp.demo
+            sleep 2
+            adb shell monkey -p com.reactnativemcp.demo -c android.intent.category.LAUNCHER 1
+            sleep 8
+            bash examples/demo-app/e2e/cli-smoke.sh --platform android
+
       - name: 실패 시 스크린샷·로그 저장
         if: failure()
         timeout-minutes: 2

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -248,6 +248,19 @@ jobs:
           max_attempts: 2
           command: node packages/react-native-mcp-server/dist/test/cli.js run examples/demo-app/e2e/all-steps.yaml -p ios -o e2e-artifacts/yaml-results --no-auto-launch
 
+      - name: CLI (rn-mcp) E2E smoke test
+        if: success()
+        timeout-minutes: 5
+        env:
+          REACT_NATIVE_MCP_TAP_TIMEOUT_MS: 25000
+        run: |
+          # YAML 테스트 후 앱이 마지막 화면에 있으므로 재시작
+          xcrun simctl terminate booted org.reactnativemcp.demo 2>/dev/null || true
+          sleep 2
+          xcrun simctl launch booted org.reactnativemcp.demo 2>/dev/null || true
+          sleep 8
+          bash examples/demo-app/e2e/cli-smoke.sh --platform ios
+
       - name: 실패 시 스크린샷·로그 저장
         if: failure()
         timeout-minutes: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,21 @@ jobs:
 
       - name: 테스트 실행
         run: bun run test:unit
+
+      - name: CLI smoke test
+        run: |
+          node packages/react-native-mcp-server/dist/cli.js --version
+          node packages/react-native-mcp-server/dist/cli.js --help | grep -q "WORKFLOW"
+          echo "✓ CLI --help and --version work"
+
+      - name: CLI init-agent test
+        run: |
+          cd "$(mktemp -d)"
+          node "$GITHUB_WORKSPACE/packages/react-native-mcp-server/dist/cli.js" init-agent --lang en
+          grep -q "rn-mcp snapshot" AGENTS.md
+          grep -q "rn-mcp snapshot" CLAUDE.md
+          # 한국어로 교체
+          node "$GITHUB_WORKSPACE/packages/react-native-mcp-server/dist/cli.js" init-agent --lang ko
+          grep -q "연결 확인" AGENTS.md
+          grep -q "연결 확인" CLAUDE.md
+          echo "✓ init-agent creates and updates guide files"

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -116,3 +116,58 @@ bun run format       # oxfmt
 - [E2E YAML Reference](document/docs/en/testing/e2e-yaml-reference.md) — YAML scenario syntax and steps
 - Runner: `packages/react-native-mcp-server/src/e2e/`
 - Config: `e2e.yaml` at project root
+
+---
+
+## CLI (rn-mcp) — AI 에이전트 권장 인터페이스
+
+셸 접근이 가능한 AI 에이전트(Claude Code, Codex 등)는 MCP 도구 대신 `rn-mcp` CLI를 사용하세요.
+Snapshot + Refs 패턴으로 토큰 소비를 크게 절감합니다.
+
+### 필수 워크플로우
+
+```bash
+# 1. 연결 확인
+rn-mcp status
+
+# 2. 화면의 interactive 요소를 @ref로 조회
+rn-mcp snapshot -i
+
+# 3. ref로 요소 조작
+rn-mcp tap @e3
+rn-mcp type @e5 "user@example.com"
+
+# 4. 화면이 바뀌었으면 snapshot 재호출
+rn-mcp snapshot -i
+```
+
+### 핵심 규칙
+
+1. **snapshot -i를 먼저** — 앱 화면을 모르는 상태에서 tap하지 마세요
+2. **화면 전환 후 snapshot 재호출** — 탭 후 화면이 바뀌면 기존 refs는 무효
+3. **ref "not found" = snapshot 필요** — `✗ @e3 not found` 에러 시 `rn-mcp snapshot -i`
+4. **스크린샷보다 assert** — `rn-mcp assert text "Welcome"`이 스크린샷보다 토큰 절약
+5. **iOS orientation 자동 처리** — CLI가 내부적으로 좌표 변환 (별도 조치 불필요)
+
+### 명령어 빠른 참조
+
+| 명령 | 용도 |
+|------|------|
+| `rn-mcp status` | 연결 상태 확인 |
+| `rn-mcp snapshot -i` | interactive 요소 + @ref 할당 |
+| `rn-mcp tap @e3` | 탭 |
+| `rn-mcp tap @e3 --long 500` | 롱프레스 |
+| `rn-mcp type @e5 "텍스트"` | 텍스트 입력 |
+| `rn-mcp swipe @e2 down` | 스와이프 |
+| `rn-mcp key back` | 하드웨어 키 (back, home, enter) |
+| `rn-mcp assert text "Welcome"` | 텍스트 존재 확인 |
+| `rn-mcp assert visible @e3` | 가시성 확인 |
+| `rn-mcp query "#btn"` | 요소 조회 |
+| `rn-mcp screenshot -o s.png` | 스크린샷 |
+
+### CLI vs MCP 선택 기준
+
+- **CLI 가능** (Claude Code, Codex 등) → `rn-mcp` CLI 사용 (토큰 효율)
+- **CLI 불가** (Cursor, Windsurf 등 MCP만 지원) → 기존 MCP 도구 사용
+
+자세한 사용법: `rn-mcp --help`

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -41,6 +41,7 @@ rn-mcp snapshot --max-depth 10   # 깊이 제한
 ```
 
 **출력 예시:**
+
 ```
 @e1  View #main-container
 @e2    ScrollView #feed
@@ -189,6 +190,7 @@ rn-mcp tap @e3
 ## 구현 계획
 
 ### Phase 1: 핵심 (MVP)
+
 - `rn-mcp snapshot [-i]` — Fiber 트리 + refs 할당
 - `rn-mcp tap @ref` — ref로 탭
 - `rn-mcp type @ref "text"` — ref로 텍스트 입력
@@ -197,12 +199,14 @@ rn-mcp tap @e3
 - 세션 파일 관리
 
 ### Phase 2: 상호작용 확장
+
 - `rn-mcp swipe`, `rn-mcp scroll`, `rn-mcp key`
 - `rn-mcp screenshot`, `rn-mcp record`
 - `rn-mcp query`, `rn-mcp query-all` (셀렉터 직접 사용)
 - `--json` 출력 모드
 
 ### Phase 3: 디버깅 & WebView
+
 - `rn-mcp console`, `rn-mcp network`
 - `rn-mcp webview eval`
 - `rn-mcp eval`
@@ -218,12 +222,14 @@ rn-mcp tap @e3
 이 프로젝트의 React Native 앱을 제어하려면 `rn-mcp` CLI를 사용하세요.
 
 ### 기본 워크플로우
+
 1. `rn-mcp status` — 앱 연결 확인
 2. `rn-mcp snapshot -i` — 화면의 interactive 요소를 @ref로 조회
 3. `rn-mcp tap @e3` — ref로 요소 탭
 4. 화면이 바뀌었으면 `rn-mcp snapshot -i`로 새 refs 획득
 
 ### 규칙
+
 - 스크린샷보다 `snapshot -i`와 `assert text`를 우선 사용 (토큰 절약)
 - tap/type 후 화면 전환이 예상되면 반드시 `snapshot -i` 재호출
 - ref가 "not found"이면 `snapshot -i`로 갱신
@@ -232,10 +238,10 @@ rn-mcp tap @e3
 
 ### MCP와 CLI 공존
 
-| 연동 방식 | 사용 도구 | 대상 |
-|-----------|-----------|------|
-| MCP 서버 | Cursor, Windsurf 등 에디터 | MCP 프로토콜 지원 클라이언트 |
-| CLI | Claude Code, Codex, 셸 스크립트 | 셸 접근 가능한 AI 에이전트 |
+| 연동 방식 | 사용 도구                       | 대상                         |
+| --------- | ------------------------------- | ---------------------------- |
+| MCP 서버  | Cursor, Windsurf 등 에디터      | MCP 프로토콜 지원 클라이언트 |
+| CLI       | Claude Code, Codex, 셸 스크립트 | 셸 접근 가능한 AI 에이전트   |
 
 동일한 WebSocket 서버(포트 12300)에 연결하므로 동시 사용 가능.
 단, refs는 CLI 세션에서만 관리 — MCP 쪽에서는 기존 query_selector 방식 유지.

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -1,0 +1,254 @@
+# react-native-mcp CLI Spec (Snapshot + Refs)
+
+## 개요
+
+기존 MCP 프로토콜은 유지하면서, AI 에이전트가 셸에서 직접 호출할 수 있는 CLI 인터페이스를 추가한다.
+agent-browser의 Snapshot+Refs 패턴을 React Native Fiber 트리에 적용.
+
+## 아키텍처
+
+```
+┌─────────┐     ┌──────────────────────┐     ┌─────────────┐
+│  AI     │────▶│  rn-mcp (CLI)        │────▶│  RN App     │
+│  Agent  │ sh  │  (경량 클라이언트)      │ WS  │  (runtime)  │
+└─────────┘     └──────────────────────┘     └─────────────┘
+                         │
+                         ▼
+                  ~/.rn-mcp/session.json  ← refs 매핑 저장
+```
+
+### 통신 구조
+
+- CLI → WebSocket 서버(포트 12300)에 직접 연결 (기존 AppSession 재사용)
+- MCP 서버를 경유하지 않음 — CLI는 독립 프로세스
+- 세션 파일(`~/.rn-mcp/session.json`)에 refs 매핑 저장 → CLI 호출 간 상태 공유
+
+## 명령어
+
+### 연결 & 상태
+
+```bash
+rn-mcp status                    # 연결 상태, 디바이스 목록
+rn-mcp devices                   # 연결된 디바이스 목록 (deviceId, platform)
+```
+
+### Snapshot (핵심)
+
+```bash
+rn-mcp snapshot                  # 전체 컴포넌트 트리 + refs 할당
+rn-mcp snapshot -i               # interactive 요소만 (Pressable, Button, TextInput 등)
+rn-mcp snapshot --max-depth 10   # 깊이 제한
+```
+
+**출력 예시:**
+```
+@e1  View #main-container
+@e2    ScrollView #feed
+@e3      Pressable #post-1 "첫 번째 게시글"
+@e4      Pressable #post-2 "두 번째 게시글"
+@e5    TextInput #search "검색..."
+@e6    Pressable #settings-btn "설정"
+```
+
+- 각 요소에 `@e1`, `@e2`, ... 순번 부여 (depth-first 순회)
+- refs는 `~/.rn-mcp/session.json`에 저장 → 이후 명령에서 사용
+- `-i` 플래그: interactive 요소만 필터 → 토큰 대폭 절감
+
+### 상호작용
+
+```bash
+rn-mcp tap @e3                   # ref로 탭 (내부: uid → 좌표 조회 → idb/adb tap)
+rn-mcp tap @e3 --long 500        # 롱프레스 (500ms)
+rn-mcp type @e5 "검색어"          # ref의 TextInput에 텍스트 입력
+rn-mcp clear @e5                 # ref의 TextInput 텍스트 삭제
+rn-mcp swipe @e2 down            # ref 요소 기준 스와이프
+rn-mcp swipe @e2 down --dist 300 # 거리 지정
+rn-mcp scroll @e2 until @e10     # @e2 내에서 @e10이 보일 때까지 스크롤
+rn-mcp key back                  # 하드웨어 버튼 (back, home, enter)
+```
+
+### 검증 (assert)
+
+```bash
+rn-mcp assert text "환영합니다"           # 화면에 텍스트 존재 확인
+rn-mcp assert visible @e3                # 요소 가시성 확인
+rn-mcp assert not-visible @e3            # 요소 비가시성 확인
+rn-mcp assert count "Pressable" 5        # 셀렉터 매칭 개수 확인
+```
+
+- exit code 0 = pass, 1 = fail
+- stdout에 pass/fail 메시지
+
+### 셀렉터 직접 사용
+
+refs 대신 기존 셀렉터도 지원 (snapshot 없이 바로 사용 가능):
+
+```bash
+rn-mcp tap "#login-btn"          # testID로 탭
+rn-mcp tap "Pressable:text(\"로그인\")"  # 셀렉터로 탭
+rn-mcp query "#login-btn"        # 요소 정보 조회 (좌표, uid 등)
+rn-mcp query-all "Pressable"     # 매칭되는 모든 요소
+```
+
+### 스크린샷 & 미디어
+
+```bash
+rn-mcp screenshot                # stdout에 base64 또는 파일 저장
+rn-mcp screenshot -o login.png   # 파일로 저장
+rn-mcp record start -o test.mp4  # 녹화 시작
+rn-mcp record stop               # 녹화 종료
+```
+
+### WebView
+
+```bash
+rn-mcp webview list              # 등록된 WebView ID 목록
+rn-mcp webview eval <id> "document.querySelector('button').click()"
+rn-mcp webview eval <id> "document.querySelector('input').value"
+```
+
+### 디바이스 제어
+
+```bash
+rn-mcp orientation               # 현재 방향
+rn-mcp orientation landscape     # 방향 변경
+rn-mcp deeplink "myapp://profile/123"
+rn-mcp location 37.5665 126.9780  # GPS 설정 (시뮬/에뮬)
+```
+
+### 디버깅
+
+```bash
+rn-mcp console                   # 콘솔 로그
+rn-mcp console --level error     # 에러만
+rn-mcp network                   # 네트워크 요청 목록
+rn-mcp eval "() => global.myVar" # 앱 컨텍스트에서 JS 실행
+```
+
+## 전역 옵션
+
+```bash
+--device, -d <id>      # 디바이스 지정 (다중 연결 시)
+--platform, -p <os>    # ios | android
+--json                 # JSON 출력 (스크립팅용)
+--port <n>             # WebSocket 포트 (기본 12300)
+--timeout <ms>         # 명령 타임아웃 (기본 10000)
+```
+
+## Refs 생명주기
+
+```
+snapshot → refs 생성 (@e1, @e2, ...)
+  ↓
+tap @e3 → 성공 (refs 유효)
+  ↓
+tap @e3 → "✗ @e3 not found — run `rn-mcp snapshot` to refresh"
+  ↓
+snapshot → 새 refs 생성 (이전 refs 전부 무효화)
+```
+
+### 규칙
+
+1. `snapshot` 호출 시 **이전 refs 전부 무효화**, 새 refs 생성
+2. ref가 가리키는 요소가 화면에 없으면 에러 반환 + exit code 1
+3. AI가 화면 전환을 예상하면 직접 `snapshot` 재호출
+4. refs는 세션 파일에 저장 → CLI 호출 간 공유
+
+### 세션 파일 구조
+
+```json
+{
+  "port": 12300,
+  "deviceId": "ios-1",
+  "platform": "ios",
+  "refs": {
+    "@e1": { "uid": "main-container", "type": "View", "testID": "main-container" },
+    "@e2": { "uid": "1.0.1", "type": "ScrollView", "testID": "feed" },
+    "@e3": { "uid": "1.0.1.0", "type": "Pressable", "testID": "post-1", "text": "첫 번째 게시글" }
+  },
+  "updatedAt": "2026-03-21T10:30:00Z"
+}
+```
+
+## ref → 좌표 변환 흐름
+
+```
+rn-mcp tap @e3
+  ↓
+1. session.json에서 @e3 → uid="1.0.1.0" 조회
+2. WebSocket으로 querySelectorWithMeasure(uid) 호출
+3. { pageX, pageY, width, height } 응답
+4. 중심 좌표 계산: (pageX + width/2, pageY + height/2)
+5. idb ui tap / adb shell input tap 실행
+6. stdout: "✓ tapped @e3 Pressable #post-1"
+```
+
+- ref에 좌표를 캐싱하지 않음 — 매번 measure 호출
+- 화면 전환/스크롤 후에도 uid가 유효하면 새 좌표로 탭 가능
+
+## 구현 계획
+
+### Phase 1: 핵심 (MVP)
+- `rn-mcp snapshot [-i]` — Fiber 트리 + refs 할당
+- `rn-mcp tap @ref` — ref로 탭
+- `rn-mcp type @ref "text"` — ref로 텍스트 입력
+- `rn-mcp assert text "..."` — 텍스트 존재 확인
+- `rn-mcp status` — 연결 상태
+- 세션 파일 관리
+
+### Phase 2: 상호작용 확장
+- `rn-mcp swipe`, `rn-mcp scroll`, `rn-mcp key`
+- `rn-mcp screenshot`, `rn-mcp record`
+- `rn-mcp query`, `rn-mcp query-all` (셀렉터 직접 사용)
+- `--json` 출력 모드
+
+### Phase 3: 디버깅 & WebView
+- `rn-mcp console`, `rn-mcp network`
+- `rn-mcp webview eval`
+- `rn-mcp eval`
+- `rn-mcp orientation`, `rn-mcp deeplink`, `rn-mcp location`
+
+## AI 에이전트 연동 방식
+
+### CLAUDE.md / AGENTS.md에 명시
+
+```markdown
+## React Native App Control
+
+이 프로젝트의 React Native 앱을 제어하려면 `rn-mcp` CLI를 사용하세요.
+
+### 기본 워크플로우
+1. `rn-mcp status` — 앱 연결 확인
+2. `rn-mcp snapshot -i` — 화면의 interactive 요소를 @ref로 조회
+3. `rn-mcp tap @e3` — ref로 요소 탭
+4. 화면이 바뀌었으면 `rn-mcp snapshot -i`로 새 refs 획득
+
+### 규칙
+- 스크린샷보다 `snapshot -i`와 `assert text`를 우선 사용 (토큰 절약)
+- tap/type 후 화면 전환이 예상되면 반드시 `snapshot -i` 재호출
+- ref가 "not found"이면 `snapshot -i`로 갱신
+- WebView 내부 요소는 `rn-mcp webview eval`로 조작
+```
+
+### MCP와 CLI 공존
+
+| 연동 방식 | 사용 도구 | 대상 |
+|-----------|-----------|------|
+| MCP 서버 | Cursor, Windsurf 등 에디터 | MCP 프로토콜 지원 클라이언트 |
+| CLI | Claude Code, Codex, 셸 스크립트 | 셸 접근 가능한 AI 에이전트 |
+
+동일한 WebSocket 서버(포트 12300)에 연결하므로 동시 사용 가능.
+단, refs는 CLI 세션에서만 관리 — MCP 쪽에서는 기존 query_selector 방식 유지.
+
+## bin 필드
+
+```json
+{
+  "bin": {
+    "react-native-mcp-server": "dist/index.js",
+    "rn-mcp": "dist/cli.js"
+  }
+}
+```
+
+별도 entry point `src/cli.ts`로 분리. 기존 `src/index.ts`(MCP 서버)는 변경 없음.

--- a/document/docs/en/mcp/_meta.json
+++ b/document/docs/en/mcp/_meta.json
@@ -1,6 +1,7 @@
 [
   { "type": "file", "name": "index", "label": "Install & connect" },
   { "type": "file", "name": "cli-init", "label": "CLI Init (Quick Setup)" },
+  { "type": "file", "name": "cli", "label": "rn-mcp CLI (Snapshot + Refs)" },
   { "type": "file", "name": "getting-started", "label": "Getting Started" },
   { "type": "file", "name": "architecture", "label": "Architecture" },
   { "type": "file", "name": "mcp-usage", "label": "Cursor / Claude / Copilot" },

--- a/document/docs/en/mcp/cli.md
+++ b/document/docs/en/mcp/cli.md
@@ -1,0 +1,192 @@
+# rn-mcp CLI (Snapshot + Refs)
+
+A shell-first interface for AI agents to control React Native apps. Uses the **Snapshot + Refs** pattern inspired by [agent-browser](https://github.com/vercel-labs/agent-browser) for token-efficient interaction.
+
+## Why CLI?
+
+| | MCP Tools | rn-mcp CLI |
+|---|---|---|
+| **Token cost** | High — full JSON responses per tool call | Low — compact refs (`@e1`, `@e2`) |
+| **Steps to tap** | query_selector → extract coords → tap (3 calls) | `rn-mcp tap @e3` (1 call) |
+| **Setup** | MCP client config required | Shell command, no config |
+| **Best for** | Cursor, Windsurf (MCP-only editors) | Claude Code, Codex, shell scripts |
+
+## Installation
+
+The CLI is included in the same package:
+
+```bash
+# Global install
+npm install -g @ohah/react-native-mcp-server
+
+# Or use npx
+npx rn-mcp --help
+
+# Or project-local
+npm install -D @ohah/react-native-mcp-server
+npx rn-mcp --help
+```
+
+## Prerequisites
+
+- MCP server must be running (started by your editor or `npx react-native-mcp-server`)
+- App must be running on a simulator/emulator and connected via WebSocket (port 12300)
+- iOS: [idb](https://fbidb.io/) installed
+- Android: [adb](https://developer.android.com/tools/adb) installed
+
+## Workflow
+
+```bash
+# 1. Check connection
+rn-mcp status
+
+# 2. Get interactive elements as @refs
+rn-mcp snapshot -i
+
+# 3. Interact using @refs
+rn-mcp tap @e3
+rn-mcp type @e5 "user@example.com"
+
+# 4. After screen transition, refresh refs
+rn-mcp snapshot -i
+```
+
+### Snapshot output example
+
+```
+@e1   View #login-screen
+@e2     TextInput #email "Email"
+@e3     TextInput #password "Password"
+@e4     Pressable #login-btn "Sign In"
+@e5     Pressable #signup-link "Create Account"
+```
+
+Each element gets a short ref (`@e1`, `@e2`, ...) assigned in depth-first order.
+
+## Commands
+
+### Connection
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp status` | Show connection status and devices |
+
+### Snapshot
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp snapshot` | Full component tree with @refs |
+| `rn-mcp snapshot -i` | Interactive elements only (recommended) |
+| `rn-mcp snapshot --max-depth 10` | Limit tree depth |
+| `rn-mcp snapshot -i --json` | JSON output for scripting |
+
+### Interaction
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp tap @e3` | Tap element by ref |
+| `rn-mcp tap "#login-btn"` | Tap by selector |
+| `rn-mcp tap @e3 --long 500` | Long press (500ms) |
+| `rn-mcp type @e5 "text"` | Type into TextInput |
+| `rn-mcp swipe @e2 down` | Swipe element |
+| `rn-mcp swipe @e2 down --dist 300` | Swipe with distance |
+| `rn-mcp key back` | Press hardware key |
+
+Available keys: `back`, `home`, `enter`, `tab`, `delete`, `up`, `down`, `left`, `right`
+
+### Assertions
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp assert text "Welcome"` | Verify text exists (exit 0/1) |
+| `rn-mcp assert visible @e3` | Verify element is visible |
+| `rn-mcp assert not-visible @e3` | Verify element is NOT visible |
+| `rn-mcp assert count "Pressable" 5` | Verify element count |
+
+### Query
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp query "#my-btn"` | Query single element info |
+| `rn-mcp query --all "Pressable"` | Query all matching elements |
+
+### Screenshot
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp screenshot` | Save screenshot (default: screenshot.png) |
+| `rn-mcp screenshot -o login.png` | Save to specific file |
+
+### Agent Guide Setup
+
+| Command | Description |
+|---------|-------------|
+| `rn-mcp init-agent` | Add CLI guide to AGENTS.md + CLAUDE.md |
+| `rn-mcp init-agent --lang ko` | Korean guide |
+| `rn-mcp init-agent --target claude` | CLAUDE.md only |
+
+## Global Options
+
+```
+-d, --device <id>        Target device (when multiple connected)
+-p, --platform <os>      ios or android
+--port <n>               WebSocket port (default: 12300)
+--json                   JSON output for scripting
+--timeout <ms>           Command timeout (default: 10000)
+```
+
+## Refs System
+
+### How refs work
+
+1. `rn-mcp snapshot -i` assigns `@e1`, `@e2`, ... to each element (depth-first order)
+2. Refs are saved to `~/.rn-mcp/session.json`
+3. Subsequent commands use refs: `rn-mcp tap @e3`
+4. Running snapshot again **invalidates all previous refs**
+
+### When to re-snapshot
+
+- After screen transitions (navigation, modal open/close)
+- When `@ref not found` error occurs
+- After actions that change the UI structure
+
+### Selectors (alternative to refs)
+
+You can also use selectors directly without snapshot:
+
+```bash
+rn-mcp tap "#login-btn"                    # by testID
+rn-mcp tap "Pressable:text(\"Sign In\")"   # by type + text
+rn-mcp tap "TextInput[placeholder=\"Email\"]"  # by attribute
+```
+
+## Important Notes
+
+- **iOS orientation** is handled automatically — no manual action needed
+- **Android dp→px conversion** is automatic
+- **Coordinates are in points (dp)**, not pixels
+- Use `--json` flag for programmatic output parsing
+
+## Example: Login Flow
+
+```bash
+# Check connection
+rn-mcp status
+
+# See what's on screen
+rn-mcp snapshot -i
+# @e1   TextInput #email "Email"
+# @e2   TextInput #password "Password"
+# @e3   Pressable #login-btn "Sign In"
+
+# Fill form and submit
+rn-mcp type @e1 "test@example.com"
+rn-mcp type @e2 "password123"
+rn-mcp tap @e3
+
+# Verify navigation
+rn-mcp assert text "Dashboard"
+
+# Get new screen's elements
+rn-mcp snapshot -i
+```

--- a/document/docs/en/mcp/cli.md
+++ b/document/docs/en/mcp/cli.md
@@ -77,7 +77,7 @@ Each element gets a short ref (`@e1`, `@e2`, ...) assigned in depth-first order.
 |---------|-------------|
 | `rn-mcp snapshot` | Full component tree with @refs |
 | `rn-mcp snapshot -i` | Interactive elements only (recommended) |
-| `rn-mcp snapshot --max-depth 10` | Limit tree depth |
+| `rn-mcp snapshot --max-depth 10` | Limit tree depth (default: 30) |
 | `rn-mcp snapshot -i --json` | JSON output for scripting |
 
 ### Interaction
@@ -89,7 +89,7 @@ Each element gets a short ref (`@e1`, `@e2`, ...) assigned in depth-first order.
 | `rn-mcp tap @e3 --long 500` | Long press (500ms) |
 | `rn-mcp type @e5 "text"` | Type into TextInput |
 | `rn-mcp swipe @e2 down` | Swipe element |
-| `rn-mcp swipe @e2 down --dist 300` | Swipe with distance |
+| `rn-mcp swipe @e2 down --dist 300` | Swipe with distance (dp) |
 | `rn-mcp key back` | Press hardware key |
 
 Available keys: `back`, `home`, `enter`, `tab`, `delete`, `up`, `down`, `left`, `right`
@@ -133,6 +133,8 @@ Available keys: `back`, `home`, `enter`, `tab`, `delete`, `up`, `down`, `left`, 
 --port <n>               WebSocket port (default: 12300)
 --json                   JSON output for scripting
 --timeout <ms>           Command timeout (default: 10000)
+-h, --help               Show help
+-v, --version            Show version
 ```
 
 ## Refs System

--- a/document/docs/ko/mcp/_meta.json
+++ b/document/docs/ko/mcp/_meta.json
@@ -1,6 +1,7 @@
 [
   { "type": "file", "name": "index", "label": "설치 및 연결" },
   { "type": "file", "name": "cli-init", "label": "CLI Init (빠른 설정)" },
+  { "type": "file", "name": "cli", "label": "rn-mcp CLI (Snapshot + Refs)" },
   { "type": "file", "name": "getting-started", "label": "시작하기" },
   { "type": "file", "name": "architecture", "label": "아키텍처" },
   { "type": "file", "name": "mcp-usage", "label": "Cursor / Claude / Copilot" },

--- a/document/docs/ko/mcp/cli.md
+++ b/document/docs/ko/mcp/cli.md
@@ -1,0 +1,193 @@
+# rn-mcp CLI (Snapshot + Refs)
+
+AI 에이전트가 셸에서 직접 React Native 앱을 제어하는 CLI 인터페이스입니다.
+[agent-browser](https://github.com/vercel-labs/agent-browser)의 **Snapshot + Refs** 패턴을 적용하여 토큰 효율적인 상호작용을 지원합니다.
+
+## 왜 CLI인가?
+
+| | MCP 도구 | rn-mcp CLI |
+|---|---|---|
+| **토큰 비용** | 높음 — 매 호출마다 전체 JSON 응답 | 낮음 — compact refs (`@e1`, `@e2`) |
+| **탭 단계** | query_selector → 좌표 추출 → tap (3회) | `rn-mcp tap @e3` (1회) |
+| **설정** | MCP 클라이언트 설정 필요 | 셸 명령, 설정 불필요 |
+| **적합 대상** | Cursor, Windsurf (MCP 전용 에디터) | Claude Code, Codex, 셸 스크립트 |
+
+## 설치
+
+CLI는 같은 패키지에 포함되어 있습니다:
+
+```bash
+# 글로벌 설치
+npm install -g @ohah/react-native-mcp-server
+
+# 또는 npx
+npx rn-mcp --help
+
+# 또는 프로젝트 로컬
+npm install -D @ohah/react-native-mcp-server
+npx rn-mcp --help
+```
+
+## 전제 조건
+
+- MCP 서버가 실행 중이어야 합니다 (에디터가 시작하거나 `npx react-native-mcp-server`)
+- 앱이 시뮬레이터/에뮬레이터에서 실행 중이고 WebSocket(포트 12300)으로 연결되어야 합니다
+- iOS: [idb](https://fbidb.io/) 설치 필요
+- Android: [adb](https://developer.android.com/tools/adb) 설치 필요
+
+## 워크플로우
+
+```bash
+# 1. 연결 확인
+rn-mcp status
+
+# 2. interactive 요소를 @ref로 조회
+rn-mcp snapshot -i
+
+# 3. @ref로 요소 조작
+rn-mcp tap @e3
+rn-mcp type @e5 "user@example.com"
+
+# 4. 화면 전환 후 refs 갱신
+rn-mcp snapshot -i
+```
+
+### Snapshot 출력 예시
+
+```
+@e1   View #login-screen
+@e2     TextInput #email "이메일"
+@e3     TextInput #password "비밀번호"
+@e4     Pressable #login-btn "로그인"
+@e5     Pressable #signup-link "회원가입"
+```
+
+각 요소에 `@e1`, `@e2`, ... 순번이 depth-first 순회로 부여됩니다.
+
+## 명령어
+
+### 연결
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp status` | 연결 상태 및 디바이스 목록 |
+
+### Snapshot
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp snapshot` | 전체 컴포넌트 트리 + @refs |
+| `rn-mcp snapshot -i` | interactive 요소만 (권장) |
+| `rn-mcp snapshot --max-depth 10` | 트리 깊이 제한 |
+| `rn-mcp snapshot -i --json` | 스크립팅용 JSON 출력 |
+
+### 상호작용
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp tap @e3` | ref로 탭 |
+| `rn-mcp tap "#login-btn"` | 셀렉터로 탭 |
+| `rn-mcp tap @e3 --long 500` | 롱프레스 (500ms) |
+| `rn-mcp type @e5 "텍스트"` | TextInput에 입력 |
+| `rn-mcp swipe @e2 down` | 스와이프 |
+| `rn-mcp swipe @e2 down --dist 300` | 거리 지정 스와이프 |
+| `rn-mcp key back` | 하드웨어 키 입력 |
+
+사용 가능한 키: `back`, `home`, `enter`, `tab`, `delete`, `up`, `down`, `left`, `right`
+
+### 검증 (Assert)
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp assert text "환영합니다"` | 텍스트 존재 확인 (exit 0/1) |
+| `rn-mcp assert visible @e3` | 요소 가시성 확인 |
+| `rn-mcp assert not-visible @e3` | 요소 비가시성 확인 |
+| `rn-mcp assert count "Pressable" 5` | 요소 개수 확인 |
+
+### 조회 (Query)
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp query "#my-btn"` | 단일 요소 정보 조회 |
+| `rn-mcp query --all "Pressable"` | 매칭되는 모든 요소 조회 |
+
+### 스크린샷
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp screenshot` | 스크린샷 저장 (기본: screenshot.png) |
+| `rn-mcp screenshot -o login.png` | 파일명 지정 |
+
+### AI 에이전트 가이드 설정
+
+| 명령 | 설명 |
+|------|------|
+| `rn-mcp init-agent` | AGENTS.md + CLAUDE.md에 CLI 가이드 추가 |
+| `rn-mcp init-agent --lang ko` | 한국어 가이드 |
+| `rn-mcp init-agent --target claude` | CLAUDE.md에만 추가 |
+
+## 전역 옵션
+
+```
+-d, --device <id>        대상 디바이스 (다중 연결 시)
+-p, --platform <os>      ios 또는 android
+--port <n>               WebSocket 포트 (기본: 12300)
+--json                   스크립팅용 JSON 출력
+--timeout <ms>           명령 타임아웃 (기본: 10000)
+```
+
+## Refs 시스템
+
+### 동작 방식
+
+1. `rn-mcp snapshot -i`가 각 요소에 `@e1`, `@e2`, ... 할당 (depth-first 순회)
+2. Refs가 `~/.rn-mcp/session.json`에 저장됨
+3. 이후 명령에서 refs 사용: `rn-mcp tap @e3`
+4. snapshot을 다시 실행하면 **이전 refs 전부 무효화**
+
+### 언제 re-snapshot 해야 하나
+
+- 화면 전환 후 (네비게이션, 모달 열기/닫기)
+- `@ref not found` 에러 발생 시
+- UI 구조가 변경되는 액션 후
+
+### 셀렉터 (refs 대안)
+
+snapshot 없이 셀렉터를 직접 사용할 수도 있습니다:
+
+```bash
+rn-mcp tap "#login-btn"                    # testID로
+rn-mcp tap "Pressable:text(\"로그인\")"     # type + text로
+rn-mcp tap "TextInput[placeholder=\"이메일\"]"  # 속성으로
+```
+
+## 주의사항
+
+- **iOS orientation**은 자동 처리됩니다 — 별도 조치 불필요
+- **Android dp→px 변환**도 자동입니다
+- **좌표는 points(dp)** 단위, 픽셀이 아닙니다
+- `--json` 플래그로 프로그래밍 방식의 출력 파싱 가능
+
+## 예시: 로그인 플로우
+
+```bash
+# 연결 확인
+rn-mcp status
+
+# 화면 요소 확인
+rn-mcp snapshot -i
+# @e1   TextInput #email "이메일"
+# @e2   TextInput #password "비밀번호"
+# @e3   Pressable #login-btn "로그인"
+
+# 폼 입력 및 제출
+rn-mcp type @e1 "test@example.com"
+rn-mcp type @e2 "password123"
+rn-mcp tap @e3
+
+# 네비게이션 확인
+rn-mcp assert text "대시보드"
+
+# 새 화면 요소 확인
+rn-mcp snapshot -i
+```

--- a/document/docs/ko/mcp/cli.md
+++ b/document/docs/ko/mcp/cli.md
@@ -78,7 +78,7 @@ rn-mcp snapshot -i
 |------|------|
 | `rn-mcp snapshot` | 전체 컴포넌트 트리 + @refs |
 | `rn-mcp snapshot -i` | interactive 요소만 (권장) |
-| `rn-mcp snapshot --max-depth 10` | 트리 깊이 제한 |
+| `rn-mcp snapshot --max-depth 10` | 트리 깊이 제한 (기본: 30) |
 | `rn-mcp snapshot -i --json` | 스크립팅용 JSON 출력 |
 
 ### 상호작용
@@ -90,7 +90,7 @@ rn-mcp snapshot -i
 | `rn-mcp tap @e3 --long 500` | 롱프레스 (500ms) |
 | `rn-mcp type @e5 "텍스트"` | TextInput에 입력 |
 | `rn-mcp swipe @e2 down` | 스와이프 |
-| `rn-mcp swipe @e2 down --dist 300` | 거리 지정 스와이프 |
+| `rn-mcp swipe @e2 down --dist 300` | 거리 지정 스와이프 (dp) |
 | `rn-mcp key back` | 하드웨어 키 입력 |
 
 사용 가능한 키: `back`, `home`, `enter`, `tab`, `delete`, `up`, `down`, `left`, `right`
@@ -134,6 +134,8 @@ rn-mcp snapshot -i
 --port <n>               WebSocket 포트 (기본: 12300)
 --json                   스크립팅용 JSON 출력
 --timeout <ms>           명령 타임아웃 (기본: 10000)
+-h, --help               도움말
+-v, --version            버전 정보
 ```
 
 ## Refs 시스템

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -8,8 +8,9 @@ set -euo pipefail
 
 PLATFORM="${1:---platform}"
 PLATFORM_VAL="${2:-ios}"
-MCP_SERVER="node packages/react-native-mcp-server/dist/index.js"
-CLI="node packages/react-native-mcp-server/dist/cli.js"
+SCRIPT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+MCP_SERVER="node $SCRIPT_DIR/packages/react-native-mcp-server/dist/index.js"
+CLI="node $SCRIPT_DIR/packages/react-native-mcp-server/dist/cli.js"
 TIMEOUT="--timeout 25000"
 MCP_PID=""
 

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -21,18 +21,20 @@ step() { echo ""; echo "── $1 ──"; }
 
 cleanup() {
   if [ -n "$MCP_PID" ]; then
-    echo "Stopping MCP server (PID $MCP_PID)..."
-    kill "$MCP_PID" 2>/dev/null || true
-    # tail -f 자식도 kill
+    echo "Stopping MCP server..."
+    # 서브셸의 자식(tail, node) 먼저 kill
     pkill -P "$MCP_PID" 2>/dev/null || true
-    wait "$MCP_PID" 2>/dev/null || true
+    kill "$MCP_PID" 2>/dev/null || true
+    # 잔여 프로세스 강제 정리 (emulator-runner 행 방지)
+    sleep 1
+    pkill -f "tail -f /dev/null" 2>/dev/null || true
+    wait 2>/dev/null || true
   fi
 }
 trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
-# MCP 서버는 stdin으로 stdio transport를 사용하므로, stdin EOF가 오면 종료됨.
-# 서브셸 안에서 tail + node를 실행하고, cleanup 시 서브셸 + 자식 전부 kill.
+# 서브셸(tail + node)로 실행, cleanup 시 pkill -P + pkill -f로 확실히 정리.
 step "0. MCP 서버 시작 (백그라운드)"
 (tail -f /dev/null | $MCP_SERVER > /dev/null 2>&1) &
 MCP_PID=$!

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -23,6 +23,8 @@ cleanup() {
   if [ -n "$MCP_PID" ]; then
     echo "Stopping MCP server (PID $MCP_PID)..."
     kill "$MCP_PID" 2>/dev/null || true
+    # tail -f 자식도 kill
+    pkill -P "$MCP_PID" 2>/dev/null || true
     wait "$MCP_PID" 2>/dev/null || true
   fi
 }
@@ -30,9 +32,9 @@ trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
 # MCP 서버는 stdin으로 stdio transport를 사용하므로, stdin EOF가 오면 종료됨.
-# tail -f /dev/null로 stdin을 영구히 열어두고, cleanup 시 kill로 정리.
+# 서브셸 안에서 tail + node를 실행하고, cleanup 시 서브셸 + 자식 전부 kill.
 step "0. MCP 서버 시작 (백그라운드)"
-tail -f /dev/null | $MCP_SERVER > /dev/null 2>&1 &
+(tail -f /dev/null | $MCP_SERVER > /dev/null 2>&1) &
 MCP_PID=$!
 echo "  MCP server PID: $MCP_PID"
 

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -21,15 +21,18 @@ step() { echo ""; echo "── $1 ──"; }
 cleanup() {
   if [ -n "$MCP_PID" ] && kill -0 "$MCP_PID" 2>/dev/null; then
     echo "Stopping MCP server (PID $MCP_PID)..."
-    kill "$MCP_PID" 2>/dev/null || true
+    # sleep infinity | node ... 로 시작했으므로 프로세스 그룹 전체 종료
+    kill -- -"$MCP_PID" 2>/dev/null || kill "$MCP_PID" 2>/dev/null || true
     wait "$MCP_PID" 2>/dev/null || true
   fi
 }
 trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
+# MCP 서버는 stdin으로 stdio transport를 사용하므로, stdin EOF가 오면 종료됨.
+# sleep infinity로 stdin을 열어두고, MCP 서버의 stdout/stderr은 /dev/null로 버림.
 step "0. MCP 서버 시작 (백그라운드)"
-$MCP_SERVER < /dev/null > /dev/null 2>&1 &
+sleep infinity | $MCP_SERVER > /dev/null 2>&1 &
 MCP_PID=$!
 echo "  MCP server PID: $MCP_PID"
 

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -19,21 +19,33 @@ pass() { echo "  ✓ $1"; }
 fail() { echo "  ✗ $1"; cleanup; exit 1; }
 step() { echo ""; echo "── $1 ──"; }
 
+MCP_FIFO=""
 cleanup() {
-  if [ -n "$MCP_PID" ] && kill -0 "$MCP_PID" 2>/dev/null; then
+  # fd 3 닫기 → MCP 서버에 EOF 전달 → 정상 종료
+  exec 3>&- 2>/dev/null || true
+  if [ -n "$MCP_PID" ]; then
     echo "Stopping MCP server (PID $MCP_PID)..."
-    # sleep infinity | node ... 로 시작했으므로 프로세스 그룹 전체 종료
-    kill -- -"$MCP_PID" 2>/dev/null || kill "$MCP_PID" 2>/dev/null || true
+    # EOF로 자연 종료 대기 (최대 2초)
+    for _ in 1 2 3 4; do
+      kill -0 "$MCP_PID" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill "$MCP_PID" 2>/dev/null || true
     wait "$MCP_PID" 2>/dev/null || true
   fi
+  [ -n "$MCP_FIFO" ] && rm -f "$MCP_FIFO" 2>/dev/null || true
 }
 trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
 # MCP 서버는 stdin으로 stdio transport를 사용하므로, stdin EOF가 오면 종료됨.
-# sleep infinity로 stdin을 열어두고, MCP 서버의 stdout/stderr은 /dev/null로 버림.
+# named pipe(FIFO)로 stdin을 열어두고, 종료 시 FIFO 삭제로 깨끗하게 정리.
 step "0. MCP 서버 시작 (백그라운드)"
-sleep infinity | $MCP_SERVER > /dev/null 2>&1 &
+MCP_FIFO=$(mktemp -u /tmp/rn-mcp-fifo.XXXXXX)
+mkfifo "$MCP_FIFO"
+# FIFO에 writer를 열어두어야 reader(MCP 서버)가 블로킹되지 않음
+exec 3>"$MCP_FIFO"
+$MCP_SERVER < "$MCP_FIFO" > /dev/null 2>&1 &
 MCP_PID=$!
 echo "  MCP server PID: $MCP_PID"
 

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -70,7 +70,7 @@ $CLI assert text "Count:" $TIMEOUT && pass "assert text found" || fail "assert t
 
 step "6. tap @ref (ref로 탭)"
 # snapshot에서 Count 버튼의 ref를 찾아서 탭
-COUNT_REF=$(echo "$SNAPSHOT" | grep 'Pressable.*"Count:' | head -1 | awk '{print $1}')
+COUNT_REF=$(echo "$SNAPSHOT" | grep 'Pressable.*"Count:' | head -1 | awk '{print $1}' || true)
 if [ -z "$COUNT_REF" ]; then
   # ref가 없으면 셀렉터로 직접 탭
   echo "  (Count ref not found in snapshot, using selector fallback)"

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -29,7 +29,7 @@ trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
 step "0. MCP 서버 시작 (백그라운드)"
-$MCP_SERVER > /dev/null 2>&1 &
+$MCP_SERVER < /dev/null > /dev/null 2>&1 &
 MCP_PID=$!
 echo "  MCP server PID: $MCP_PID"
 

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# rn-mcp CLI E2E smoke test
+# MCP 서버를 백그라운드로 시작하고, CLI로 앱을 제어하는 통합 테스트.
+# 앱은 이미 시뮬레이터/에뮬레이터에서 실행 중이어야 함.
+#
+# Usage: bash examples/demo-app/e2e/cli-smoke.sh [--platform ios|android]
+set -euo pipefail
+
+PLATFORM="${1:---platform}"
+PLATFORM_VAL="${2:-ios}"
+MCP_SERVER="node packages/react-native-mcp-server/dist/index.js"
+CLI="node packages/react-native-mcp-server/dist/cli.js"
+TIMEOUT="--timeout 25000"
+MCP_PID=""
+
+# 도움말: 함수 정의
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; cleanup; exit 1; }
+step() { echo ""; echo "── $1 ──"; }
+
+cleanup() {
+  if [ -n "$MCP_PID" ] && kill -0 "$MCP_PID" 2>/dev/null; then
+    echo "Stopping MCP server (PID $MCP_PID)..."
+    kill "$MCP_PID" 2>/dev/null || true
+    wait "$MCP_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# MCP 서버 시작 (WebSocket 서버 제공)
+step "0. MCP 서버 시작 (백그라운드)"
+$MCP_SERVER > /dev/null 2>&1 &
+MCP_PID=$!
+echo "  MCP server PID: $MCP_PID"
+
+# 앱이 WebSocket에 연결될 때까지 대기 (최대 30초)
+echo "  Waiting for app to connect..."
+for i in $(seq 1 30); do
+  if $CLI status --timeout 3000 2>&1 | grep -q "Connected"; then
+    pass "app connected (${i}s)"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    fail "app did not connect within 30s"
+  fi
+  sleep 1
+done
+
+step "1. CLI --help / --version"
+$CLI --version | grep -q "rn-mcp v" && pass "--version" || fail "--version"
+$CLI --help | grep -q "WORKFLOW" && pass "--help" || fail "--help"
+
+step "2. status (디바이스 정보 확인)"
+$CLI status $TIMEOUT 2>&1 | grep -q "$PLATFORM_VAL\|Connected" && pass "status shows device" || fail "status"
+
+step "3. snapshot -i (interactive 요소 조회)"
+SNAPSHOT=$($CLI snapshot -i $TIMEOUT 2>&1)
+echo "$SNAPSHOT" | head -10
+echo "$SNAPSHOT" | grep -q "@e1" && pass "snapshot refs assigned" || fail "snapshot: no refs"
+echo "$SNAPSHOT" | grep -q "Pressable\|Button\|TextInput" && pass "snapshot has interactive elements" || fail "snapshot: no interactive elements"
+
+step "4. snapshot --json (JSON 출력)"
+$CLI snapshot -i --json $TIMEOUT 2>&1 | grep -q '"refs"' && pass "snapshot --json" || fail "snapshot --json"
+
+step "5. assert text (텍스트 검증)"
+$CLI assert text "Count:" $TIMEOUT && pass "assert text found" || fail "assert text"
+
+step "6. tap @ref (ref로 탭)"
+# snapshot에서 Count 버튼의 ref를 찾아서 탭
+COUNT_REF=$(echo "$SNAPSHOT" | grep 'Pressable.*"Count:' | head -1 | awk '{print $1}')
+if [ -z "$COUNT_REF" ]; then
+  # ref가 없으면 셀렉터로 직접 탭
+  echo "  (Count ref not found in snapshot, using selector fallback)"
+  $CLI tap 'Pressable:text("Count:")' $TIMEOUT && pass "tap by selector" || fail "tap by selector"
+else
+  $CLI tap "$COUNT_REF" $TIMEOUT && pass "tap $COUNT_REF" || fail "tap $COUNT_REF"
+fi
+sleep 2
+
+step "7. assert text after tap (탭 후 텍스트 변경 확인)"
+# Count가 증가했으면 "Count: " 뒤에 0보다 큰 숫자
+$CLI assert text "Count:" $TIMEOUT && pass "text still exists after tap" || fail "text gone after tap"
+
+step "8. query (셀렉터 조회)"
+$CLI query 'Pressable:text("Count:")' $TIMEOUT 2>&1 | grep -q "Pressable" && pass "query" || fail "query"
+
+step "9. snapshot 재호출 (refs 갱신)"
+NEW_SNAPSHOT=$($CLI snapshot -i $TIMEOUT 2>&1)
+echo "$NEW_SNAPSHOT" | grep -q "@e1" && pass "re-snapshot" || fail "re-snapshot"
+
+step "10. init-agent (가이드 생성)"
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+$CLI init-agent --lang en 2>&1
+[ -f AGENTS.md ] && grep -q "rn-mcp" AGENTS.md && pass "init-agent AGENTS.md" || fail "init-agent AGENTS.md"
+[ -f CLAUDE.md ] && grep -q "rn-mcp" CLAUDE.md && pass "init-agent CLAUDE.md" || fail "init-agent CLAUDE.md"
+rm -rf "$TMPDIR"
+
+echo ""
+echo "═══════════════════════════════════"
+echo "  ✓ All CLI smoke tests passed!"
+echo "═══════════════════════════════════"

--- a/examples/demo-app/e2e/cli-smoke.sh
+++ b/examples/demo-app/e2e/cli-smoke.sh
@@ -19,33 +19,20 @@ pass() { echo "  ✓ $1"; }
 fail() { echo "  ✗ $1"; cleanup; exit 1; }
 step() { echo ""; echo "── $1 ──"; }
 
-MCP_FIFO=""
 cleanup() {
-  # fd 3 닫기 → MCP 서버에 EOF 전달 → 정상 종료
-  exec 3>&- 2>/dev/null || true
   if [ -n "$MCP_PID" ]; then
     echo "Stopping MCP server (PID $MCP_PID)..."
-    # EOF로 자연 종료 대기 (최대 2초)
-    for _ in 1 2 3 4; do
-      kill -0 "$MCP_PID" 2>/dev/null || break
-      sleep 0.5
-    done
     kill "$MCP_PID" 2>/dev/null || true
     wait "$MCP_PID" 2>/dev/null || true
   fi
-  [ -n "$MCP_FIFO" ] && rm -f "$MCP_FIFO" 2>/dev/null || true
 }
 trap cleanup EXIT
 
 # MCP 서버 시작 (WebSocket 서버 제공)
 # MCP 서버는 stdin으로 stdio transport를 사용하므로, stdin EOF가 오면 종료됨.
-# named pipe(FIFO)로 stdin을 열어두고, 종료 시 FIFO 삭제로 깨끗하게 정리.
+# tail -f /dev/null로 stdin을 영구히 열어두고, cleanup 시 kill로 정리.
 step "0. MCP 서버 시작 (백그라운드)"
-MCP_FIFO=$(mktemp -u /tmp/rn-mcp-fifo.XXXXXX)
-mkfifo "$MCP_FIFO"
-# FIFO에 writer를 열어두어야 reader(MCP 서버)가 블로킹되지 않음
-exec 3>"$MCP_FIFO"
-$MCP_SERVER < "$MCP_FIFO" > /dev/null 2>&1 &
+tail -f /dev/null | $MCP_SERVER > /dev/null 2>&1 &
 MCP_PID=$!
 echo "  MCP server PID: $MCP_PID"
 

--- a/packages/react-native-mcp-server/package.json
+++ b/packages/react-native-mcp-server/package.json
@@ -21,7 +21,8 @@
     "directory": "packages/react-native-mcp-server"
   },
   "bin": {
-    "react-native-mcp-server": "dist/index.js"
+    "react-native-mcp-server": "dist/index.js",
+    "rn-mcp": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/packages/react-native-mcp-server/src/__tests__/cli/agent-guide.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/agent-guide.test.ts
@@ -1,0 +1,100 @@
+/**
+ * CLI init-agent 가이드 텍스트 테스트.
+ * 마커 존재, 한영 버전 구조, 교체 로직 검증.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { GUIDE_EN, GUIDE_KO, MARKER_START, MARKER_END } from '../../cli/agent-guide.js';
+
+describe('agent-guide', () => {
+  it('영어 가이드에 마커 포함', () => {
+    expect(GUIDE_EN).toContain(MARKER_START);
+    expect(GUIDE_EN).toContain(MARKER_END);
+  });
+
+  it('한국어 가이드에 마커 포함', () => {
+    expect(GUIDE_KO).toContain(MARKER_START);
+    expect(GUIDE_KO).toContain(MARKER_END);
+  });
+
+  it('영어 가이드에 필수 명령어 포함', () => {
+    expect(GUIDE_EN).toContain('rn-mcp status');
+    expect(GUIDE_EN).toContain('rn-mcp snapshot -i');
+    expect(GUIDE_EN).toContain('rn-mcp tap');
+    expect(GUIDE_EN).toContain('rn-mcp type');
+    expect(GUIDE_EN).toContain('rn-mcp assert');
+  });
+
+  it('한국어 가이드에 필수 명령어 포함', () => {
+    expect(GUIDE_KO).toContain('rn-mcp status');
+    expect(GUIDE_KO).toContain('rn-mcp snapshot -i');
+    expect(GUIDE_KO).toContain('rn-mcp tap');
+  });
+
+  it('영어 가이드에 워크플로우 순서 포함', () => {
+    expect(GUIDE_EN).toContain('Check connection');
+    expect(GUIDE_EN).toContain('snapshot -i');
+    expect(GUIDE_EN).toContain('screen transition');
+  });
+
+  it('한국어 가이드에 워크플로우 순서 포함', () => {
+    expect(GUIDE_KO).toContain('연결 확인');
+    expect(GUIDE_KO).toContain('snapshot -i');
+    expect(GUIDE_KO).toContain('화면 전환');
+  });
+});
+
+describe('init-agent file operations', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'rn-mcp-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('기존 파일에 가이드 추가', () => {
+    const filePath = path.join(tmpDir, 'AGENTS.md');
+    writeFileSync(filePath, '# My Project\n\nSome content.\n');
+
+    // 가이드 추가
+    const content = readFileSync(filePath, 'utf8');
+    writeFileSync(filePath, content + '\n' + GUIDE_EN + '\n');
+
+    const result = readFileSync(filePath, 'utf8');
+    expect(result).toContain('# My Project');
+    expect(result).toContain('Some content.');
+    expect(result).toContain(MARKER_START);
+    expect(result).toContain('rn-mcp snapshot -i');
+    expect(result).toContain(MARKER_END);
+  });
+
+  it('기존 가이드 교체', () => {
+    const filePath = path.join(tmpDir, 'CLAUDE.md');
+    // 영어 가이드가 이미 있는 파일
+    writeFileSync(filePath, `# Claude\n\n${GUIDE_EN}\n\n## Other section\n`);
+
+    // 한국어로 교체
+    const content = readFileSync(filePath, 'utf8');
+    const regex = new RegExp(
+      `${MARKER_START.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${MARKER_END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+      'g'
+    );
+    const updated = content.replace(regex, GUIDE_KO);
+    writeFileSync(filePath, updated);
+
+    const result = readFileSync(filePath, 'utf8');
+    expect(result).toContain('# Claude');
+    expect(result).toContain('## Other section');
+    // 한국어로 교체됨
+    expect(result).toContain('연결 확인');
+    // 영어 워크플로우는 없어야 함
+    expect(result).not.toContain('Check connection');
+    // 마커는 한 쌍만
+    expect(result.split(MARKER_START).length).toBe(2);
+  });
+});

--- a/packages/react-native-mcp-server/src/__tests__/cli/cli-help.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/cli-help.test.ts
@@ -6,10 +6,7 @@ import { describe, expect, it } from 'bun:test';
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
-const CLI_PATH = path.resolve(
-  import.meta.dirname,
-  '../../../dist/cli.js'
-);
+const CLI_PATH = path.resolve(import.meta.dirname, '../../../dist/cli.js');
 
 function runCli(args: string[]): string {
   return execFileSync('node', [CLI_PATH, ...args], {

--- a/packages/react-native-mcp-server/src/__tests__/cli/cli-help.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/cli-help.test.ts
@@ -1,0 +1,69 @@
+/**
+ * CLI --help / --version 출력 테스트.
+ * 빌드된 dist/cli.js가 정상 동작하는지 smoke test.
+ */
+import { describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const CLI_PATH = path.resolve(
+  import.meta.dirname,
+  '../../../dist/cli.js'
+);
+
+function runCli(args: string[]): string {
+  return execFileSync('node', [CLI_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+}
+
+describe('CLI smoke tests', () => {
+  it('--help 출력에 필수 섹션 포함', () => {
+    const output = runCli(['--help']);
+    expect(output).toContain('rn-mcp');
+    expect(output).toContain('USAGE');
+    expect(output).toContain('WORKFLOW');
+    expect(output).toContain('COMMANDS');
+    expect(output).toContain('snapshot');
+    expect(output).toContain('tap');
+    expect(output).toContain('type');
+    expect(output).toContain('assert');
+    expect(output).toContain('REFS SYSTEM');
+    expect(output).toContain('EXAMPLES');
+    expect(output).toContain('init-agent');
+  });
+
+  it('--help에 iOS orientation 자동 처리 안내', () => {
+    const output = runCli(['--help']);
+    expect(output).toContain('iOS');
+    expect(output).toContain('orientation');
+  });
+
+  it('--help에 @ref 설명', () => {
+    const output = runCli(['--help']);
+    expect(output).toContain('@e1');
+    expect(output).toContain('@e2');
+    expect(output).toContain('session.json');
+  });
+
+  it('--version 출력', () => {
+    const output = runCli(['--version']);
+    expect(output.trim()).toMatch(/^rn-mcp v\d+\.\d+\.\d+/);
+  });
+
+  it('인자 없으면 help 출력', () => {
+    const output = runCli([]);
+    expect(output).toContain('USAGE');
+  });
+
+  it('잘못된 명령 → exit code 1', () => {
+    try {
+      runCli(['nonexistent-command']);
+      expect(true).toBe(false); // should not reach
+    } catch (err: any) {
+      expect(err.status).toBe(1);
+      expect(err.stderr.toString()).toContain('Unknown command');
+    }
+  });
+});

--- a/packages/react-native-mcp-server/src/__tests__/cli/ref-map.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/ref-map.test.ts
@@ -38,9 +38,7 @@ const sampleTree = {
     {
       uid: 'no-info',
       type: 'View',
-      children: [
-        { uid: 'nested-btn', type: 'Button', text: '확인' },
-      ],
+      children: [{ uid: 'nested-btn', type: 'Button', text: '확인' }],
     },
   ],
 };
@@ -72,7 +70,14 @@ describe('assignRefs', () => {
       // root(depth=0)는 항상 포함, 나머지는 interactive만
       if (t === 'View') continue; // root
       expect(
-        ['TextInput', 'Pressable', 'Button', 'TouchableOpacity', 'TouchableHighlight', 'Switch'].includes(t)
+        [
+          'TextInput',
+          'Pressable',
+          'Button',
+          'TouchableOpacity',
+          'TouchableHighlight',
+          'Switch',
+        ].includes(t)
       ).toBe(true);
     }
 

--- a/packages/react-native-mcp-server/src/__tests__/cli/ref-map.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/ref-map.test.ts
@@ -1,0 +1,133 @@
+/**
+ * CLI ref-map 테스트.
+ * Snapshot 트리에서 @e1, @e2, ... refs 할당 로직 검증.
+ */
+import { describe, expect, it } from 'bun:test';
+import { assignRefs } from '../../cli/ref-map.js';
+
+const sampleTree = {
+  uid: 'root',
+  type: 'View',
+  testID: 'app-root',
+  children: [
+    {
+      uid: 'header',
+      type: 'View',
+      testID: 'header',
+      children: [
+        { uid: 'title', type: 'Text', text: 'Welcome' },
+        { uid: 'subtitle', type: 'Text', text: 'Hello world' },
+      ],
+    },
+    {
+      uid: 'email-input',
+      type: 'TextInput',
+      testID: 'email-input',
+    },
+    {
+      uid: 'login-btn',
+      type: 'Pressable',
+      testID: 'login-btn',
+      text: '로그인',
+    },
+    {
+      uid: '1.0.3',
+      type: 'Pressable',
+      text: '회원가입',
+    },
+    {
+      uid: 'no-info',
+      type: 'View',
+      children: [
+        { uid: 'nested-btn', type: 'Button', text: '확인' },
+      ],
+    },
+  ],
+};
+
+describe('assignRefs', () => {
+  it('전체 모드: 의미 있는 모든 노드에 ref 할당', () => {
+    const { refs, lines } = assignRefs(sampleTree, false);
+
+    // refs에 @e1부터 순번이 할당되어야 함
+    expect(Object.keys(refs).length).toBeGreaterThan(0);
+    expect(refs['@e1']).toBeDefined();
+
+    // root 노드가 @e1
+    expect(refs['@e1']!.type).toBe('View');
+    expect(refs['@e1']!.testID).toBe('app-root');
+
+    // lines가 생성되어야 함
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('@e1');
+    expect(lines[0]).toContain('View');
+  });
+
+  it('interactive 모드: interactive 요소만 포함', () => {
+    const { refs, lines } = assignRefs(sampleTree, true);
+
+    // TextInput, Pressable, Button만 포함
+    const types = Object.values(refs).map((r) => r.type);
+    for (const t of types) {
+      // root(depth=0)는 항상 포함, 나머지는 interactive만
+      if (t === 'View') continue; // root
+      expect(
+        ['TextInput', 'Pressable', 'Button', 'TouchableOpacity', 'TouchableHighlight', 'Switch'].includes(t)
+      ).toBe(true);
+    }
+
+    // Text 노드는 포함되지 않아야 함
+    const hasText = Object.values(refs).some((r) => r.type === 'Text');
+    expect(hasText).toBe(false);
+  });
+
+  it('ref에 uid, type, testID, text 저장', () => {
+    const { refs } = assignRefs(sampleTree, false);
+
+    // testID가 있는 요소
+    const loginRef = Object.values(refs).find((r) => r.testID === 'login-btn');
+    expect(loginRef).toBeDefined();
+    expect(loginRef!.uid).toBe('login-btn');
+    expect(loginRef!.type).toBe('Pressable');
+    expect(loginRef!.text).toBe('로그인');
+
+    // testID가 없는 요소
+    const signupRef = Object.values(refs).find((r) => r.text === '회원가입');
+    expect(signupRef).toBeDefined();
+    expect(signupRef!.uid).toBe('1.0.3');
+    expect(signupRef!.testID).toBeUndefined();
+  });
+
+  it('depth-first 순회 순서', () => {
+    const { lines } = assignRefs(sampleTree, false);
+
+    // @e1이 @e2보다 먼저, 형제는 선언 순서
+    const refOrder = lines.map((l) => l.match(/@e\d+/)?.[0]).filter(Boolean);
+    expect(refOrder[0]).toBe('@e1');
+
+    // 순번이 증가해야 함
+    for (let i = 1; i < refOrder.length; i++) {
+      const prev = parseInt(refOrder[i - 1]!.replace('@e', ''), 10);
+      const curr = parseInt(refOrder[i]!.replace('@e', ''), 10);
+      expect(curr).toBe(prev + 1);
+    }
+  });
+
+  it('빈 트리', () => {
+    const { refs, lines } = assignRefs({ type: 'View', uid: 'root' }, false);
+    // root만 있어도 @e1 할당
+    expect(refs['@e1']).toBeDefined();
+    expect(lines.length).toBe(1);
+  });
+
+  it('lines 포맷: ref + indent + type + testID + text', () => {
+    const { lines } = assignRefs(sampleTree, false);
+
+    // root: "@e1   View #app-root"
+    expect(lines[0]).toMatch(/^@e1\s+View #app-root$/);
+
+    // text가 있는 줄: 따옴표로 감싸져야 함
+    const textLine = lines.find((l) => l.includes('"Welcome"'));
+    expect(textLine).toBeDefined();
+  });
+});

--- a/packages/react-native-mcp-server/src/__tests__/cli/session.test.ts
+++ b/packages/react-native-mcp-server/src/__tests__/cli/session.test.ts
@@ -1,0 +1,48 @@
+/**
+ * CLI session 테스트.
+ * ~/.rn-mcp/session.json 관리 로직 검증.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// session.ts의 SESSION_DIR을 직접 테스트하기 어려우므로 resolveRef만 단위 테스트
+import { resolveRef, type Session } from '../../cli/session.js';
+
+describe('resolveRef', () => {
+  const session: Session = {
+    port: 12300,
+    deviceId: 'ios-1',
+    platform: 'ios',
+    refs: {
+      '@e1': { uid: 'root', type: 'View', testID: 'app-root' },
+      '@e2': { uid: 'login-btn', type: 'Pressable', testID: 'login-btn', text: '로그인' },
+      '@e3': { uid: '1.0.3', type: 'Pressable', text: '회원가입' },
+    },
+    updatedAt: '2026-03-21T10:00:00Z',
+  };
+
+  it('유효한 ref 반환', () => {
+    const ref = resolveRef(session, '@e2');
+    expect(ref.uid).toBe('login-btn');
+    expect(ref.type).toBe('Pressable');
+    expect(ref.testID).toBe('login-btn');
+    expect(ref.text).toBe('로그인');
+  });
+
+  it('testID 없는 ref도 반환', () => {
+    const ref = resolveRef(session, '@e3');
+    expect(ref.uid).toBe('1.0.3');
+    expect(ref.testID).toBeUndefined();
+    expect(ref.text).toBe('회원가입');
+  });
+
+  it('존재하지 않는 ref → 에러', () => {
+    expect(() => resolveRef(session, '@e99')).toThrow('@e99 not found');
+  });
+
+  it('에러 메시지에 snapshot 안내 포함', () => {
+    expect(() => resolveRef(session, '@e10')).toThrow('snapshot');
+  });
+});

--- a/packages/react-native-mcp-server/src/cli.ts
+++ b/packages/react-native-mcp-server/src/cli.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * rn-mcp CLI — React Native 앱 제어 CLI (Snapshot + Refs 패턴)
+ *
+ * MCP 프로토콜 없이 셸에서 직접 React Native 앱을 제어.
+ * AI 에이전트 (Claude Code, Codex 등)가 셸 명령으로 앱과 상호작용.
+ */
+
+import { parseArgs } from 'node:util';
+import { VERSION } from './version.js';
+
+// ─── Help text ───────────────────────────────────────────────────
+
+const HELP = `
+rn-mcp v${VERSION} — React Native app control CLI (Snapshot + Refs)
+
+USAGE
+  rn-mcp <command> [options]
+
+WORKFLOW (IMPORTANT — follow this order)
+  1. rn-mcp status              Check connection (is the app running?)
+  2. rn-mcp snapshot -i         Get interactive elements as @refs
+  3. rn-mcp tap @e3             Interact using @refs
+  4. rn-mcp snapshot -i         Refresh refs after screen change
+
+  ⚠ iOS: orientation is handled automatically during tap/swipe.
+  ⚠ Refs become invalid after screen transitions — re-run snapshot.
+  ⚠ If a ref returns "not found", run snapshot -i to refresh.
+
+COMMANDS
+  status                        Show connection status and devices
+  snapshot [-i] [--max-depth N] Capture component tree with @refs
+    -i, --interactive           Interactive elements only (recommended)
+    --max-depth N               Tree depth limit (default: 30)
+
+  tap <@ref|selector>           Tap an element
+    --long <ms>                 Long press duration in ms
+
+  type <@ref|selector> <text>   Type text into TextInput
+
+  swipe <@ref|selector> <dir>   Swipe on element
+    <dir>: up, down, left, right
+    --dist <dp>                 Swipe distance in dp
+
+  key <button>                  Press hardware button
+    <button>: back, home, enter, tab, delete, up, down, left, right
+
+  assert text <text>            Verify text exists on screen
+  assert visible <@ref|sel>     Verify element is visible
+  assert not-visible <@ref|sel> Verify element is NOT visible
+  assert count <selector> <n>   Verify element count
+
+  query <selector>              Query element info (coords, uid)
+  query --all <selector>        Query all matching elements
+
+  screenshot [-o <file>]        Save screenshot
+
+  init-agent                    Add CLI guide to AGENTS.md / CLAUDE.md
+    --target <agents|claude|all>  Target file (default: all)
+    --lang <en|ko>              Guide language (default: en)
+
+GLOBAL OPTIONS
+  -d, --device <id>             Target device (when multiple connected)
+  -p, --platform <ios|android>  Target platform
+  --port <n>                    WebSocket port (default: 12300)
+  --json                        JSON output for scripting
+  --timeout <ms>                Command timeout (default: 10000)
+  -h, --help                    Show this help
+  -v, --version                 Show version
+
+REFS SYSTEM
+  snapshot assigns @e1, @e2, ... to each element (depth-first order).
+  Use refs in subsequent commands: tap @e3, type @e5 "hello"
+  Refs are saved to ~/.rn-mcp/session.json between CLI calls.
+  Running snapshot again invalidates ALL previous refs.
+
+SELECTORS (alternative to refs)
+  #testID                       Match by testID
+  Type                          Match by component type (e.g. Pressable)
+  Type#testID                   Combine type and testID
+  Type:text("label")            Match by type and text content
+  #parent > #child              Direct child combinator
+  See: npx react-native-mcp-server doctor for full syntax
+
+EXAMPLES
+  rn-mcp status
+  rn-mcp snapshot -i
+  rn-mcp tap @e3
+  rn-mcp tap "#login-btn"
+  rn-mcp tap @e3 --long 500
+  rn-mcp type @e5 "user@example.com"
+  rn-mcp swipe @e2 down --dist 300
+  rn-mcp key back
+  rn-mcp assert text "Welcome"
+  rn-mcp assert visible @e3
+  rn-mcp query "#my-button"
+  rn-mcp screenshot -o login.png
+
+PREREQUISITES
+  - MCP server must be running (started by your editor or manually)
+  - App must be connected via WebSocket (port 12300)
+  - iOS: idb installed (brew tap facebook/fb && brew install idb-companion)
+  - Android: adb installed (brew install android-platform-tools)
+`.trim();
+
+// ─── Arg parsing ─────────────────────────────────────────────────
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    help: { type: 'boolean', short: 'h', default: false },
+    version: { type: 'boolean', short: 'v', default: false },
+    device: { type: 'string', short: 'd' },
+    platform: { type: 'string', short: 'p' },
+    port: { type: 'string', default: '12300' },
+    json: { type: 'boolean', default: false },
+    timeout: { type: 'string', default: '10000' },
+    interactive: { type: 'boolean', short: 'i', default: false },
+    'max-depth': { type: 'string', default: '30' },
+    long: { type: 'string' },
+    dist: { type: 'string' },
+    all: { type: 'boolean', default: false },
+    output: { type: 'string', short: 'o' },
+    target: { type: 'string', default: 'all' },
+    lang: { type: 'string', default: 'en' },
+  },
+  allowPositionals: true,
+  strict: false,
+});
+
+if (values.version) {
+  console.log(`rn-mcp v${VERSION}`);
+  process.exit(0);
+}
+
+if (values.help || positionals.length === 0) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const globalOpts = {
+  device: values.device as string | undefined,
+  platform: values.platform as string | undefined,
+  port: parseInt(values.port as string, 10),
+  json: values.json as boolean,
+  timeout: parseInt(values.timeout as string, 10),
+};
+
+// ─── Command routing ─────────────────────────────────────────────
+
+const command = positionals[0];
+const restArgs = positionals.slice(1);
+
+async function run(): Promise<void> {
+  // Lazy import to speed up --help/--version
+  const {
+    cmdStatus,
+    cmdSnapshot,
+    cmdTap,
+    cmdType,
+    cmdAssert,
+    cmdQuery,
+    cmdSwipe,
+    cmdKey,
+    cmdScreenshot,
+    cmdInitAgent,
+  } = await import('./cli/commands.js');
+
+  switch (command) {
+    case 'status':
+      return cmdStatus(globalOpts);
+
+    case 'snapshot':
+      return cmdSnapshot({
+        ...globalOpts,
+        interactive: values.interactive as boolean,
+        maxDepth: parseInt(values['max-depth'] as string, 10),
+      });
+
+    case 'tap': {
+      const target = restArgs[0];
+      if (!target) {
+        console.error('Usage: rn-mcp tap <@ref|selector>');
+        process.exit(1);
+      }
+      return cmdTap(target, {
+        ...globalOpts,
+        long: values.long ? parseInt(values.long as string, 10) : undefined,
+      });
+    }
+
+    case 'type': {
+      const target = restArgs[0];
+      const text = restArgs[1];
+      if (!target || text == null) {
+        console.error('Usage: rn-mcp type <@ref|selector> <text>');
+        process.exit(1);
+      }
+      return cmdType(target, text, globalOpts);
+    }
+
+    case 'assert': {
+      const sub = restArgs[0];
+      if (!sub) {
+        console.error('Usage: rn-mcp assert <text|visible|not-visible|count> ...');
+        process.exit(1);
+      }
+      return cmdAssert(sub, restArgs.slice(1), globalOpts);
+    }
+
+    case 'query': {
+      const selector = restArgs[0];
+      if (!selector) {
+        console.error('Usage: rn-mcp query <selector> [--all]');
+        process.exit(1);
+      }
+      return cmdQuery(selector, { ...globalOpts, all: values.all as boolean });
+    }
+
+    case 'swipe': {
+      const target = restArgs[0];
+      const direction = restArgs[1];
+      if (!target || !direction) {
+        console.error('Usage: rn-mcp swipe <@ref|selector> <up|down|left|right>');
+        process.exit(1);
+      }
+      return cmdSwipe(target, direction, {
+        ...globalOpts,
+        dist: values.dist ? parseInt(values.dist as string, 10) : undefined,
+      });
+    }
+
+    case 'key': {
+      const button = restArgs[0];
+      if (!button) {
+        console.error('Usage: rn-mcp key <back|home|enter|tab|delete|up|down|left|right>');
+        process.exit(1);
+      }
+      return cmdKey(button, globalOpts);
+    }
+
+    case 'screenshot':
+      return cmdScreenshot({
+        ...globalOpts,
+        output: values.output as string | undefined,
+      });
+
+    case 'init-agent':
+      return cmdInitAgent({
+        target: values.target as string,
+        lang: values.lang as string,
+      });
+
+    default:
+      console.error(`Unknown command: ${command}\nRun \`rn-mcp --help\` for usage.`);
+      process.exit(1);
+  }
+}
+
+run().catch((err: Error) => {
+  console.error(`✗ ${err.message}`);
+  process.exit(1);
+});

--- a/packages/react-native-mcp-server/src/cli/agent-guide.ts
+++ b/packages/react-native-mcp-server/src/cli/agent-guide.ts
@@ -1,0 +1,123 @@
+/**
+ * rn-mcp init-agent 명령용 가이드 텍스트.
+ * AGENTS.md / CLAUDE.md에 삽입할 CLI 사용 가이드.
+ */
+
+const MARKER_START = '<!-- rn-mcp-cli-guide:start -->';
+const MARKER_END = '<!-- rn-mcp-cli-guide:end -->';
+
+export { MARKER_START, MARKER_END };
+
+export const GUIDE_EN = `${MARKER_START}
+## rn-mcp CLI — React Native App Control
+
+Use the \`rn-mcp\` CLI to control the React Native app from the shell.
+It uses a Snapshot + Refs pattern for token-efficient interaction.
+
+### Required Workflow
+
+\`\`\`bash
+# 1. Check connection
+rn-mcp status
+
+# 2. Get interactive elements as @refs
+rn-mcp snapshot -i
+
+# 3. Interact using @refs
+rn-mcp tap @e3
+rn-mcp type @e5 "user@example.com"
+
+# 4. After screen transition, refresh refs
+rn-mcp snapshot -i
+\`\`\`
+
+### Rules
+
+1. **Always run \`snapshot -i\` first** before interacting with the app
+2. **Re-run \`snapshot -i\` after screen transitions** — old refs become invalid
+3. **\`@ref not found\` means refs are stale** — run \`snapshot -i\` to refresh
+4. **Prefer \`assert text\` over screenshots** — much lower token cost
+5. **iOS orientation is handled automatically** — no manual action needed
+
+### Command Reference
+
+| Command | Description |
+|---------|-------------|
+| \`rn-mcp status\` | Check connection status |
+| \`rn-mcp snapshot -i\` | List interactive elements with @refs |
+| \`rn-mcp tap @e3\` | Tap element |
+| \`rn-mcp tap @e3 --long 500\` | Long press (500ms) |
+| \`rn-mcp type @e5 "text"\` | Type into TextInput |
+| \`rn-mcp swipe @e2 down\` | Swipe element |
+| \`rn-mcp key back\` | Press hardware key (back, home, enter) |
+| \`rn-mcp assert text "Welcome"\` | Verify text on screen (exit 0/1) |
+| \`rn-mcp assert visible @e3\` | Verify element visibility |
+| \`rn-mcp query "#btn"\` | Query element info |
+| \`rn-mcp screenshot -o s.png\` | Save screenshot |
+
+### Selectors (alternative to @refs)
+
+\`\`\`bash
+rn-mcp tap "#login-btn"              # by testID
+rn-mcp tap "Pressable:text(\\"Go\\")"  # by type + text
+\`\`\`
+
+Run \`rn-mcp --help\` for full documentation.
+${MARKER_END}`;
+
+export const GUIDE_KO = `${MARKER_START}
+## rn-mcp CLI — React Native 앱 제어
+
+\`rn-mcp\` CLI로 셸에서 React Native 앱을 제어할 수 있습니다.
+Snapshot + Refs 패턴으로 토큰 효율적인 상호작용을 지원합니다.
+
+### 필수 워크플로우
+
+\`\`\`bash
+# 1. 연결 확인
+rn-mcp status
+
+# 2. interactive 요소를 @ref로 조회
+rn-mcp snapshot -i
+
+# 3. @ref로 요소 조작
+rn-mcp tap @e3
+rn-mcp type @e5 "user@example.com"
+
+# 4. 화면 전환 후 refs 갱신
+rn-mcp snapshot -i
+\`\`\`
+
+### 규칙
+
+1. **반드시 \`snapshot -i\`부터** — 화면을 모르는 상태에서 tap하지 마세요
+2. **화면 전환 후 \`snapshot -i\` 재호출** — 기존 refs는 무효화됩니다
+3. **\`@ref not found\` = refs 갱신 필요** — \`snapshot -i\`를 다시 실행하세요
+4. **스크린샷보다 \`assert text\`** — 토큰 비용이 훨씬 낮습니다
+5. **iOS orientation 자동 처리** — 별도 조치 불필요
+
+### 명령어 참조
+
+| 명령 | 설명 |
+|------|------|
+| \`rn-mcp status\` | 연결 상태 확인 |
+| \`rn-mcp snapshot -i\` | interactive 요소 + @ref 할당 |
+| \`rn-mcp tap @e3\` | 요소 탭 |
+| \`rn-mcp tap @e3 --long 500\` | 롱프레스 (500ms) |
+| \`rn-mcp type @e5 "텍스트"\` | TextInput에 텍스트 입력 |
+| \`rn-mcp swipe @e2 down\` | 스와이프 |
+| \`rn-mcp key back\` | 하드웨어 키 (back, home, enter) |
+| \`rn-mcp assert text "환영합니다"\` | 텍스트 존재 확인 (exit 0/1) |
+| \`rn-mcp assert visible @e3\` | 요소 가시성 확인 |
+| \`rn-mcp query "#btn"\` | 요소 정보 조회 |
+| \`rn-mcp screenshot -o s.png\` | 스크린샷 저장 |
+
+### 셀렉터 (@ref 대안)
+
+\`\`\`bash
+rn-mcp tap "#login-btn"              # testID로
+rn-mcp tap "Pressable:text(\\"이동\\")"  # type + text로
+\`\`\`
+
+전체 문서: \`rn-mcp --help\`
+${MARKER_END}`;

--- a/packages/react-native-mcp-server/src/cli/commands.ts
+++ b/packages/react-native-mcp-server/src/cli/commands.ts
@@ -1,0 +1,711 @@
+/**
+ * CLI 명령어 구현.
+ * 각 명령은 WebSocket extension client로 앱과 통신하고,
+ * idb/adb를 직접 실행하여 디바이스를 제어한다.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { WsClient, type DeviceInfo } from './ws-client.js';
+import { loadSession, saveSession, resolveRef, type Session } from './session.js';
+import { GUIDE_EN, GUIDE_KO, MARKER_START, MARKER_END } from './agent-guide.js';
+import { assignRefs } from './ref-map.js';
+import { resolveUdid, runIdbCommand, checkIdbAvailable } from '../tools/idb-utils.js';
+import {
+  resolveSerial,
+  runAdbCommand,
+  checkAdbAvailable,
+  getAndroidScale,
+  getAndroidTopInset,
+} from '../tools/adb-utils.js';
+import { transformForIdb, type IOSOrientationInfo } from '../tools/ios-landscape.js';
+
+const execFileAsync = promisify(execFile);
+
+// ─── Eval code builders (인라인 — tools/ 의존 최소화) ────────────
+
+function evalGetComponentTree(maxDepth: number): string {
+  return `(function(){ return typeof __REACT_NATIVE_MCP__ !== 'undefined' && __REACT_NATIVE_MCP__.getComponentTree ? __REACT_NATIVE_MCP__.getComponentTree({ maxDepth: ${maxDepth} }) : null; })();`;
+}
+
+function evalQuerySelector(selector: string): string {
+  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.querySelectorWithMeasure ? M.querySelectorWithMeasure(${JSON.stringify(selector)}) : null; })();`;
+}
+
+function evalQuerySelectorAll(selector: string): string {
+  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.querySelectorAllWithMeasure ? M.querySelectorAllWithMeasure(${JSON.stringify(selector)}) : []; })();`;
+}
+
+function evalGetScreenInfo(): string {
+  return '(function(){ var M = typeof __REACT_NATIVE_MCP__ !== "undefined" ? __REACT_NATIVE_MCP__ : null; return M && M.getScreenInfo ? M.getScreenInfo() : null; })();';
+}
+
+function evalAssertText(text: string): string {
+  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.assertText ? M.assertText(${JSON.stringify(text)}) : null; })();`;
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────
+
+interface CliOptions {
+  device?: string;
+  platform?: string;
+  port: number;
+  json: boolean;
+  timeout: number;
+}
+
+async function connectAndResolveDevice(
+  opts: CliOptions
+): Promise<{ ws: WsClient; device: DeviceInfo }> {
+  const ws = await WsClient.connect(opts.port, opts.timeout);
+  const devices = ws.devices;
+
+  if (devices.length === 0) {
+    ws.close();
+    throw new Error(
+      'No React Native app connected.\n' +
+        'Make sure the app is running and connected to the MCP server.'
+    );
+  }
+
+  let device: DeviceInfo;
+  if (opts.device) {
+    const found = devices.find((d) => d.deviceId === opts.device);
+    if (!found) {
+      ws.close();
+      const available = devices.map((d) => `  ${d.deviceId} (${d.platform})`).join('\n');
+      throw new Error(`Device "${opts.device}" not found.\nAvailable:\n${available}`);
+    }
+    device = found;
+  } else if (opts.platform) {
+    const found = devices.filter((d) => d.platform === opts.platform);
+    if (found.length === 0) {
+      ws.close();
+      throw new Error(`No ${opts.platform} device connected.`);
+    }
+    if (found.length > 1) {
+      ws.close();
+      const list = found.map((d) => `  ${d.deviceId}`).join('\n');
+      throw new Error(`Multiple ${opts.platform} devices. Specify --device:\n${list}`);
+    }
+    device = found[0]!;
+  } else if (devices.length > 1) {
+    ws.close();
+    const list = devices.map((d) => `  ${d.deviceId} (${d.platform})`).join('\n');
+    throw new Error(`Multiple devices connected. Specify --device or --platform:\n${list}`);
+  } else {
+    device = devices[0]!;
+  }
+
+  return { ws, device };
+}
+
+/**
+ * ref 또는 selector에서 요소의 좌표를 가져온다.
+ * @ref → session에서 uid/testID 조회 → selector 빌드 → querySelectorWithMeasure
+ * selector → 직접 querySelectorWithMeasure
+ */
+async function resolveElementCoords(
+  ws: WsClient,
+  target: string,
+  device: DeviceInfo
+): Promise<{ pageX: number; pageY: number; width: number; height: number; uid: string }> {
+  let selector: string;
+  let filterUid: string | undefined;
+
+  if (target.startsWith('@e')) {
+    const session = loadSession();
+    if (!session || Object.keys(session.refs).length === 0) {
+      throw new Error(`No refs available. Run \`rn-mcp snapshot -i\` first.`);
+    }
+    const ref = resolveRef(session, target);
+
+    if (ref.testID) {
+      selector = `#${ref.testID}`;
+    } else if (ref.text) {
+      selector = `${ref.type}:text(${JSON.stringify(ref.text)})`;
+    } else {
+      // testID도 text도 없는 요소 → type으로 전부 조회 후 uid로 필터
+      selector = ref.type;
+      filterUid = ref.uid;
+    }
+  } else {
+    selector = target;
+  }
+
+  let result: Record<string, unknown> | null = null;
+
+  if (filterUid) {
+    const all = (await ws.eval(
+      evalQuerySelectorAll(selector),
+      device.deviceId,
+      device.platform
+    )) as Record<string, unknown>[];
+    const match = all?.find((el) => el.uid === filterUid);
+    if (match) result = match;
+  } else {
+    result = (await ws.eval(
+      evalQuerySelector(selector),
+      device.deviceId,
+      device.platform
+    )) as Record<string, unknown> | null;
+  }
+
+  if (!result) {
+    throw new Error(
+      `${target} not found on screen. Run \`rn-mcp snapshot -i\` to refresh refs.`
+    );
+  }
+
+  return {
+    pageX: Number(result.pageX ?? 0),
+    pageY: Number(result.pageY ?? 0),
+    width: Number(result.width ?? 0),
+    height: Number(result.height ?? 0),
+    uid: String(result.uid ?? ''),
+  };
+}
+
+/**
+ * iOS orientation 정보 수집 (CLI용).
+ * appSession 없이 ws-client로 eval.
+ */
+async function getIOSOrientation(
+  ws: WsClient,
+  device: DeviceInfo,
+  udid: string
+): Promise<IOSOrientationInfo> {
+  const defaultInfo: IOSOrientationInfo = { graphicsOrientation: 1, width: 0, height: 0 };
+  if (device.platform !== 'ios') return defaultInfo;
+
+  let width = 0;
+  let height = 0;
+  try {
+    const info = (await ws.eval(evalGetScreenInfo(), device.deviceId, device.platform)) as {
+      window?: { width: number; height: number };
+    } | null;
+    if (info?.window) {
+      width = info.window.width;
+      height = info.window.height;
+    }
+  } catch {
+    return defaultInfo;
+  }
+
+  let graphicsOrientation = 1;
+  try {
+    const { stdout } = await execFileAsync(
+      'xcrun',
+      ['simctl', 'spawn', udid, 'defaults', 'read', 'com.apple.backboardd'],
+      { timeout: 3000 }
+    );
+    const match = stdout.match(/GraphicsOrientation\s*=\s*(\d+)/);
+    if (match?.[1]) graphicsOrientation = parseInt(match[1], 10);
+  } catch {
+    // default portrait
+  }
+
+  return { graphicsOrientation, width, height };
+}
+
+// ─── Commands ────────────────────────────────────────────────────
+
+/**
+ * rn-mcp status
+ */
+export async function cmdStatus(opts: CliOptions): Promise<void> {
+  const ws = await WsClient.connect(opts.port, opts.timeout);
+  const devices = ws.devices;
+
+  if (devices.length === 0) {
+    console.log('No devices connected.');
+  } else {
+    console.log(`Connected devices: ${devices.length}`);
+    for (const d of devices) {
+      console.log(`  ${d.deviceId} (${d.platform})${d.deviceName ? ` — ${d.deviceName}` : ''}`);
+    }
+  }
+
+  const session = loadSession();
+  if (session && Object.keys(session.refs).length > 0) {
+    console.log(`\nActive refs: ${Object.keys(session.refs).length} (from ${session.updatedAt})`);
+  }
+
+  ws.close();
+}
+
+/**
+ * rn-mcp snapshot [-i] [--max-depth N]
+ */
+export async function cmdSnapshot(
+  opts: CliOptions & { interactive: boolean; maxDepth: number }
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  const tree = await ws.eval(evalGetComponentTree(opts.maxDepth), device.deviceId, device.platform);
+  if (!tree) {
+    console.error('Snapshot unavailable (DevTools hook or fiber root missing).');
+    ws.close();
+    process.exit(1);
+  }
+
+  const { refs, lines } = assignRefs(tree as any, opts.interactive);
+
+  // 세션 저장
+  const session: Session = {
+    port: opts.port,
+    deviceId: device.deviceId,
+    platform: device.platform,
+    refs,
+    updatedAt: '',
+  };
+  saveSession(session);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ refs, deviceId: device.deviceId, platform: device.platform }));
+  } else {
+    if (lines.length === 0) {
+      console.log('(empty tree)');
+    } else {
+      for (const line of lines) {
+        console.log(line);
+      }
+    }
+    console.error(`\n${Object.keys(refs).length} refs saved.`);
+  }
+
+  ws.close();
+}
+
+/**
+ * rn-mcp tap <@ref|selector> [--long <ms>]
+ */
+export async function cmdTap(
+  target: string,
+  opts: CliOptions & { long?: number }
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  const el = await resolveElementCoords(ws, target, device);
+  const cx = el.pageX + el.width / 2;
+  const cy = el.pageY + el.height / 2;
+  const isLongPress = opts.long != null && opts.long > 0;
+
+  try {
+    if (device.platform === 'ios') {
+      if (!(await checkIdbAvailable())) {
+        throw new Error('idb not installed. Run: brew tap facebook/fb && brew install idb-companion');
+      }
+      const udid = await resolveUdid(device.deviceId);
+      const orientInfo = await getIOSOrientation(ws, device, udid);
+      const t = transformForIdb(cx, cy, orientInfo);
+      const ix = Math.round(t.x);
+      const iy = Math.round(t.y);
+      const cmd = ['ui', 'tap', String(ix), String(iy)];
+      if (isLongPress) cmd.push('--duration', String(opts.long! / 1000));
+      await runIdbCommand(cmd, udid, { timeoutMs: opts.timeout });
+    } else {
+      if (!(await checkAdbAvailable())) {
+        throw new Error('adb not installed. Run: brew install android-platform-tools');
+      }
+      const serial = await resolveSerial(device.deviceId);
+      const scale = await getAndroidScale(serial);
+      const topInsetPx = await getAndroidTopInset(serial);
+      const topInsetDp = topInsetPx / scale;
+      const px = Math.round(cx * scale);
+      const py = Math.round((cy + topInsetDp) * scale);
+      if (isLongPress) {
+        await runAdbCommand(
+          ['shell', 'input', 'swipe', String(px), String(py), String(px), String(py), String(opts.long!)],
+          serial,
+          { timeoutMs: opts.timeout }
+        );
+      } else {
+        await runAdbCommand(['shell', 'input', 'tap', String(px), String(py)], serial, {
+          timeoutMs: opts.timeout,
+        });
+      }
+    }
+
+    // UI 업데이트 대기
+    await new Promise((r) => setTimeout(r, 300));
+
+    const label = target.startsWith('@e')
+      ? `${target} ${loadSession()?.refs[target]?.type ?? ''}${loadSession()?.refs[target]?.testID ? ' #' + loadSession()?.refs[target]?.testID : ''}`
+      : target;
+    console.log(`✓ ${isLongPress ? 'long-pressed' : 'tapped'} ${label.trim()}`);
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp type <@ref|selector> <text>
+ */
+export async function cmdType(
+  target: string,
+  text: string,
+  opts: CliOptions
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  // 요소 찾기 (존재 확인 + uid 획득)
+  const el = await resolveElementCoords(ws, target, device);
+
+  // type_text는 uid로 직접 텍스트 입력
+  const code = `(function(){
+    var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null;
+    return M && M.typeText ? M.typeText(${JSON.stringify(el.uid)}, ${JSON.stringify(text)}) : null;
+  })();`;
+
+  try {
+    await ws.eval(code, device.deviceId, device.platform);
+    console.log(`✓ typed "${text}" into ${target}`);
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp assert text <text>
+ * rn-mcp assert visible <@ref|selector>
+ * rn-mcp assert not-visible <@ref|selector>
+ * rn-mcp assert count <selector> <n>
+ */
+export async function cmdAssert(
+  subcommand: string,
+  args: string[],
+  opts: CliOptions
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  try {
+    switch (subcommand) {
+      case 'text': {
+        const text = args[0];
+        if (!text) throw new Error('Usage: rn-mcp assert text <text>');
+        // Fiber 트리에서 텍스트 검색
+        const tree = await ws.eval(evalGetComponentTree(30), device.deviceId, device.platform);
+        const found = tree ? JSON.stringify(tree).includes(text) : false;
+        if (found) {
+          console.log(`✓ text "${text}" found`);
+        } else {
+          console.log(`✗ text "${text}" not found`);
+          process.exitCode = 1;
+        }
+        break;
+      }
+      case 'visible': {
+        const target = args[0];
+        if (!target) throw new Error('Usage: rn-mcp assert visible <@ref|selector>');
+        try {
+          await resolveElementCoords(ws, target, device);
+          console.log(`✓ ${target} is visible`);
+        } catch {
+          console.log(`✗ ${target} is not visible`);
+          process.exitCode = 1;
+        }
+        break;
+      }
+      case 'not-visible': {
+        const target = args[0];
+        if (!target) throw new Error('Usage: rn-mcp assert not-visible <@ref|selector>');
+        try {
+          await resolveElementCoords(ws, target, device);
+          console.log(`✗ ${target} is visible (expected not visible)`);
+          process.exitCode = 1;
+        } catch {
+          console.log(`✓ ${target} is not visible`);
+        }
+        break;
+      }
+      case 'count': {
+        const selector = args[0];
+        const expected = parseInt(args[1] ?? '', 10);
+        if (!selector || isNaN(expected)) {
+          throw new Error('Usage: rn-mcp assert count <selector> <n>');
+        }
+        const list = (await ws.eval(
+          evalQuerySelectorAll(selector),
+          device.deviceId,
+          device.platform
+        )) as unknown[];
+        const actual = Array.isArray(list) ? list.length : 0;
+        if (actual === expected) {
+          console.log(`✓ ${selector}: ${actual} matches`);
+        } else {
+          console.log(`✗ ${selector}: expected ${expected}, got ${actual}`);
+          process.exitCode = 1;
+        }
+        break;
+      }
+      default:
+        throw new Error(
+          `Unknown assert subcommand: ${subcommand}\n` +
+            'Available: text, visible, not-visible, count'
+        );
+    }
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp query <selector>
+ */
+export async function cmdQuery(
+  selector: string,
+  opts: CliOptions & { all: boolean }
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  try {
+    if (opts.all) {
+      const list = (await ws.eval(
+        evalQuerySelectorAll(selector),
+        device.deviceId,
+        device.platform
+      )) as Record<string, unknown>[];
+      if (!Array.isArray(list) || list.length === 0) {
+        console.log(`No elements match: ${selector}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(list, null, 2));
+      } else {
+        console.log(`# ${list.length} matches`);
+        for (const el of list) {
+          const parts = [String(el.type ?? 'element')];
+          if (el.testID) parts.push(`#${el.testID}`);
+          if (el.uid && el.uid !== el.testID) parts.push(`uid=${el.uid}`);
+          if (el.pageX != null) parts.push(`pageX=${Math.round(Number(el.pageX))}`);
+          if (el.pageY != null) parts.push(`pageY=${Math.round(Number(el.pageY))}`);
+          if (el.width != null) parts.push(`w=${Math.round(Number(el.width))}`);
+          if (el.height != null) parts.push(`h=${Math.round(Number(el.height))}`);
+          console.log(`- ${parts.join(' ')}`);
+        }
+      }
+    } else {
+      const result = (await ws.eval(
+        evalQuerySelector(selector),
+        device.deviceId,
+        device.platform
+      )) as Record<string, unknown> | null;
+      if (!result) {
+        console.log(`No element matches: ${selector}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        const parts = [String(result.type ?? 'element')];
+        if (result.testID) parts.push(`#${result.testID}`);
+        if (result.uid && result.uid !== result.testID) parts.push(`uid=${result.uid}`);
+        if (result.pageX != null) parts.push(`pageX=${Math.round(Number(result.pageX))}`);
+        if (result.pageY != null) parts.push(`pageY=${Math.round(Number(result.pageY))}`);
+        if (result.width != null) parts.push(`w=${Math.round(Number(result.width))}`);
+        if (result.height != null) parts.push(`h=${Math.round(Number(result.height))}`);
+        console.log(parts.join(' '));
+      }
+    }
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp swipe <@ref|selector> <direction> [--dist <px>]
+ */
+export async function cmdSwipe(
+  target: string,
+  direction: string,
+  opts: CliOptions & { dist?: number }
+): Promise<void> {
+  const validDirs = ['up', 'down', 'left', 'right'];
+  if (!validDirs.includes(direction)) {
+    throw new Error(`Invalid direction: ${direction}. Use: ${validDirs.join(', ')}`);
+  }
+
+  const { ws, device } = await connectAndResolveDevice(opts);
+  const el = await resolveElementCoords(ws, target, device);
+  const cx = el.pageX + el.width / 2;
+  const cy = el.pageY + el.height / 2;
+  const dist = opts.dist ?? Math.min(el.width, el.height) * 0.6;
+
+  let x1: number, y1: number, x2: number, y2: number;
+  switch (direction) {
+    case 'up':    x1 = cx; y1 = cy + dist / 2; x2 = cx; y2 = cy - dist / 2; break;
+    case 'down':  x1 = cx; y1 = cy - dist / 2; x2 = cx; y2 = cy + dist / 2; break;
+    case 'left':  x1 = cx + dist / 2; y1 = cy; x2 = cx - dist / 2; y2 = cy; break;
+    case 'right': x1 = cx - dist / 2; y1 = cy; x2 = cx + dist / 2; y2 = cy; break;
+    default: throw new Error('unreachable');
+  }
+
+  try {
+    if (device.platform === 'ios') {
+      if (!(await checkIdbAvailable())) throw new Error('idb not installed');
+      const udid = await resolveUdid(device.deviceId);
+      const orientInfo = await getIOSOrientation(ws, device, udid);
+      const t1 = transformForIdb(x1, y1, orientInfo);
+      const t2 = transformForIdb(x2, y2, orientInfo);
+      await runIdbCommand(
+        ['ui', 'swipe', String(Math.round(t1.x)), String(Math.round(t1.y)),
+         String(Math.round(t2.x)), String(Math.round(t2.y))],
+        udid,
+        { timeoutMs: opts.timeout }
+      );
+    } else {
+      if (!(await checkAdbAvailable())) throw new Error('adb not installed');
+      const serial = await resolveSerial(device.deviceId);
+      const scale = await getAndroidScale(serial);
+      const topInsetPx = await getAndroidTopInset(serial);
+      const topInsetDp = topInsetPx / scale;
+      const px1 = Math.round(x1 * scale);
+      const py1 = Math.round((y1 + topInsetDp) * scale);
+      const px2 = Math.round(x2 * scale);
+      const py2 = Math.round((y2 + topInsetDp) * scale);
+      await runAdbCommand(
+        ['shell', 'input', 'swipe', String(px1), String(py1), String(px2), String(py2), '300'],
+        serial,
+        { timeoutMs: opts.timeout }
+      );
+    }
+
+    await new Promise((r) => setTimeout(r, 300));
+    console.log(`✓ swiped ${direction} on ${target}`);
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp key <button>
+ */
+export async function cmdKey(button: string, opts: CliOptions): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  try {
+    if (device.platform === 'ios') {
+      if (!(await checkIdbAvailable())) throw new Error('idb not installed');
+      const udid = await resolveUdid(device.deviceId);
+      const idbButton = button === 'back' ? 'HOME' : button.toUpperCase();
+      await runIdbCommand(['ui', 'button', idbButton], udid, { timeoutMs: opts.timeout });
+    } else {
+      if (!(await checkAdbAvailable())) throw new Error('adb not installed');
+      const serial = await resolveSerial(device.deviceId);
+      const keycodeMap: Record<string, number> = {
+        back: 4, home: 3, enter: 66, tab: 61, delete: 67,
+        up: 19, down: 20, left: 21, right: 22,
+      };
+      const keycode = keycodeMap[button.toLowerCase()];
+      if (keycode == null) {
+        throw new Error(
+          `Unknown key: ${button}. Available: ${Object.keys(keycodeMap).join(', ')}`
+        );
+      }
+      await runAdbCommand(['shell', 'input', 'keyevent', String(keycode)], serial, {
+        timeoutMs: opts.timeout,
+      });
+    }
+
+    console.log(`✓ pressed ${button}`);
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp screenshot [-o <file>]
+ */
+export async function cmdScreenshot(
+  opts: CliOptions & { output?: string }
+): Promise<void> {
+  const { ws, device } = await connectAndResolveDevice(opts);
+
+  try {
+    if (device.platform === 'ios') {
+      if (!(await checkIdbAvailable())) throw new Error('idb not installed');
+      const udid = await resolveUdid(device.deviceId);
+      const outFile = opts.output ?? 'screenshot.png';
+      await runIdbCommand(['screenshot', '--path', outFile], udid, { timeoutMs: opts.timeout });
+      console.log(`✓ saved ${outFile}`);
+    } else {
+      if (!(await checkAdbAvailable())) throw new Error('adb not installed');
+      const serial = await resolveSerial(device.deviceId);
+      const outFile = opts.output ?? 'screenshot.png';
+      await runAdbCommand(['exec-out', 'screencap', '-p'], serial, { timeoutMs: opts.timeout });
+      // screencap binary output → file
+      const { execFile: execFileCb } = await import('node:child_process');
+      const { writeFileSync } = await import('node:fs');
+      const { runCommand } = await import('../tools/run-command.js');
+      const buf = await runCommand(
+        'adb',
+        [...(serial ? ['-s', serial] : []), 'exec-out', 'screencap', '-p'],
+        { timeoutMs: opts.timeout }
+      );
+      writeFileSync(outFile, buf);
+      console.log(`✓ saved ${outFile}`);
+    }
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * rn-mcp init-agent [--target agents|claude] [--lang en|ko]
+ * AGENTS.md 또는 CLAUDE.md에 CLI 사용 가이드를 추가.
+ */
+export async function cmdInitAgent(
+  opts: { target: string; lang: string }
+): Promise<void> {
+  const targets: Array<{ file: string; label: string }> = [];
+
+  if (opts.target === 'all' || opts.target === 'agents') {
+    targets.push({ file: 'AGENTS.md', label: 'AGENTS.md' });
+  }
+  if (opts.target === 'all' || opts.target === 'claude') {
+    targets.push({ file: 'CLAUDE.md', label: 'CLAUDE.md' });
+  }
+
+  if (targets.length === 0) {
+    throw new Error('Invalid --target. Use: agents, claude, or all');
+  }
+
+  const guide = opts.lang === 'ko' ? GUIDE_KO : GUIDE_EN;
+
+  for (const { file, label } of targets) {
+    const filePath = path.resolve(process.cwd(), file);
+
+    if (existsSync(filePath)) {
+      const content = readFileSync(filePath, 'utf8');
+
+      // 이미 가이드가 있으면 교체
+      if (content.includes(MARKER_START)) {
+        const regex = new RegExp(
+          `${escapeRegex(MARKER_START)}[\\s\\S]*?${escapeRegex(MARKER_END)}`,
+          'g'
+        );
+        const updated = content.replace(regex, guide);
+        writeFileSync(filePath, updated);
+        console.log(`✓ ${label}: guide updated`);
+      } else {
+        // 없으면 끝에 추가
+        const separator = content.endsWith('\n') ? '\n' : '\n\n';
+        writeFileSync(filePath, content + separator + guide + '\n');
+        console.log(`✓ ${label}: guide appended`);
+      }
+    } else {
+      // 파일이 없으면 새로 생성
+      writeFileSync(filePath, `# ${file.replace('.md', '')}\n\n${guide}\n`);
+      console.log(`✓ ${label}: created with guide`);
+    }
+  }
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/react-native-mcp-server/src/cli/commands.ts
+++ b/packages/react-native-mcp-server/src/cli/commands.ts
@@ -47,8 +47,15 @@ function evalGetScreenInfo(): string {
 // ─── 공유 상수 ───────────────────────────────────────────────────
 
 const ANDROID_KEYCODES: Record<string, number> = {
-  back: 4, home: 3, enter: 66, tab: 61, delete: 67,
-  up: 19, down: 20, left: 21, right: 22,
+  back: 4,
+  home: 3,
+  enter: 66,
+  tab: 61,
+  delete: 67,
+  up: 19,
+  down: 20,
+  left: 21,
+  right: 22,
 };
 
 const VALID_DIRECTIONS = ['up', 'down', 'left', 'right'] as const;
@@ -161,9 +168,7 @@ async function resolveElementCoords(
   }
 
   if (!result) {
-    throw new Error(
-      `${target} not found on screen. Run \`rn-mcp snapshot -i\` to refresh refs.`
-    );
+    throw new Error(`${target} not found on screen. Run \`rn-mcp snapshot -i\` to refresh refs.`);
   }
 
   return {
@@ -301,10 +306,7 @@ export async function cmdSnapshot(
 /**
  * rn-mcp tap <@ref|selector> [--long <ms>]
  */
-export async function cmdTap(
-  target: string,
-  opts: CliOptions & { long?: number }
-): Promise<void> {
+export async function cmdTap(target: string, opts: CliOptions & { long?: number }): Promise<void> {
   const { ws, device } = await connectAndResolveDevice(opts);
 
   const el = await resolveElementCoords(ws, target, device);
@@ -315,7 +317,9 @@ export async function cmdTap(
   try {
     if (device.platform === 'ios') {
       if (!(await checkIdbAvailable())) {
-        throw new Error('idb not installed. Run: brew tap facebook/fb && brew install idb-companion');
+        throw new Error(
+          'idb not installed. Run: brew tap facebook/fb && brew install idb-companion'
+        );
       }
       const udid = await resolveUdid(device.deviceId);
       const orientInfo = await getIOSOrientation(ws, device, udid);
@@ -337,7 +341,16 @@ export async function cmdTap(
       const py = Math.round((cy + topInsetDp) * scale);
       if (isLongPress) {
         await runAdbCommand(
-          ['shell', 'input', 'swipe', String(px), String(py), String(px), String(py), String(opts.long!)],
+          [
+            'shell',
+            'input',
+            'swipe',
+            String(px),
+            String(py),
+            String(px),
+            String(py),
+            String(opts.long!),
+          ],
           serial,
           { timeoutMs: opts.timeout }
         );
@@ -366,11 +379,7 @@ export async function cmdTap(
 /**
  * rn-mcp type <@ref|selector> <text>
  */
-export async function cmdType(
-  target: string,
-  text: string,
-  opts: CliOptions
-): Promise<void> {
+export async function cmdType(target: string, text: string, opts: CliOptions): Promise<void> {
   const { ws, device } = await connectAndResolveDevice(opts);
 
   // 요소 찾기 (존재 확인 + uid 획득)
@@ -549,11 +558,32 @@ export async function cmdSwipe(
 
   let x1: number, y1: number, x2: number, y2: number;
   switch (direction) {
-    case 'up':    x1 = cx; y1 = cy + dist / 2; x2 = cx; y2 = cy - dist / 2; break;
-    case 'down':  x1 = cx; y1 = cy - dist / 2; x2 = cx; y2 = cy + dist / 2; break;
-    case 'left':  x1 = cx + dist / 2; y1 = cy; x2 = cx - dist / 2; y2 = cy; break;
-    case 'right': x1 = cx - dist / 2; y1 = cy; x2 = cx + dist / 2; y2 = cy; break;
-    default: throw new Error('unreachable');
+    case 'up':
+      x1 = cx;
+      y1 = cy + dist / 2;
+      x2 = cx;
+      y2 = cy - dist / 2;
+      break;
+    case 'down':
+      x1 = cx;
+      y1 = cy - dist / 2;
+      x2 = cx;
+      y2 = cy + dist / 2;
+      break;
+    case 'left':
+      x1 = cx + dist / 2;
+      y1 = cy;
+      x2 = cx - dist / 2;
+      y2 = cy;
+      break;
+    case 'right':
+      x1 = cx - dist / 2;
+      y1 = cy;
+      x2 = cx + dist / 2;
+      y2 = cy;
+      break;
+    default:
+      throw new Error('unreachable');
   }
 
   try {
@@ -564,8 +594,14 @@ export async function cmdSwipe(
       const t1 = transformForIdb(x1, y1, orientInfo);
       const t2 = transformForIdb(x2, y2, orientInfo);
       await runIdbCommand(
-        ['ui', 'swipe', String(Math.round(t1.x)), String(Math.round(t1.y)),
-         String(Math.round(t2.x)), String(Math.round(t2.y))],
+        [
+          'ui',
+          'swipe',
+          String(Math.round(t1.x)),
+          String(Math.round(t1.y)),
+          String(Math.round(t2.x)),
+          String(Math.round(t2.y)),
+        ],
         udid,
         { timeoutMs: opts.timeout }
       );
@@ -628,9 +664,7 @@ export async function cmdKey(button: string, opts: CliOptions): Promise<void> {
 /**
  * rn-mcp screenshot [-o <file>]
  */
-export async function cmdScreenshot(
-  opts: CliOptions & { output?: string }
-): Promise<void> {
+export async function cmdScreenshot(opts: CliOptions & { output?: string }): Promise<void> {
   const { ws, device } = await connectAndResolveDevice(opts);
 
   try {
@@ -661,9 +695,7 @@ export async function cmdScreenshot(
  * rn-mcp init-agent [--target agents|claude] [--lang en|ko]
  * AGENTS.md 또는 CLAUDE.md에 CLI 사용 가이드를 추가.
  */
-export async function cmdInitAgent(
-  opts: { target: string; lang: string }
-): Promise<void> {
+export async function cmdInitAgent(opts: { target: string; lang: string }): Promise<void> {
   const targets: Array<{ file: string; label: string }> = [];
 
   if (opts.target === 'all' || opts.target === 'agents') {

--- a/packages/react-native-mcp-server/src/cli/commands.ts
+++ b/packages/react-native-mcp-server/src/cli/commands.ts
@@ -6,7 +6,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { WsClient, type DeviceInfo } from './ws-client.js';
 import { loadSession, saveSession, resolveRef, type Session } from './session.js';
@@ -21,30 +21,37 @@ import {
   getAndroidTopInset,
 } from '../tools/adb-utils.js';
 import { transformForIdb, type IOSOrientationInfo } from '../tools/ios-landscape.js';
+import {
+  buildQuerySelectorEvalCode,
+  buildQuerySelectorAllEvalCode,
+} from '../tools/query-selector.js';
+import { runCommand } from '../tools/run-command.js';
 
 const execFileAsync = promisify(execFile);
 
-// ─── Eval code builders (인라인 — tools/ 의존 최소화) ────────────
+// ─── Eval code builders ─────────────────────────────────────────
+
+/** __REACT_NATIVE_MCP__ 메서드 호출 eval 코드 생성 */
+function buildEvalCall(method: string, ...args: string[]): string {
+  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.${method} ? M.${method}(${args.join(', ')}) : null; })();`;
+}
 
 function evalGetComponentTree(maxDepth: number): string {
-  return `(function(){ return typeof __REACT_NATIVE_MCP__ !== 'undefined' && __REACT_NATIVE_MCP__.getComponentTree ? __REACT_NATIVE_MCP__.getComponentTree({ maxDepth: ${maxDepth} }) : null; })();`;
-}
-
-function evalQuerySelector(selector: string): string {
-  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.querySelectorWithMeasure ? M.querySelectorWithMeasure(${JSON.stringify(selector)}) : null; })();`;
-}
-
-function evalQuerySelectorAll(selector: string): string {
-  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.querySelectorAllWithMeasure ? M.querySelectorAllWithMeasure(${JSON.stringify(selector)}) : []; })();`;
+  return buildEvalCall('getComponentTree', `{ maxDepth: ${maxDepth} }`);
 }
 
 function evalGetScreenInfo(): string {
-  return '(function(){ var M = typeof __REACT_NATIVE_MCP__ !== "undefined" ? __REACT_NATIVE_MCP__ : null; return M && M.getScreenInfo ? M.getScreenInfo() : null; })();';
+  return buildEvalCall('getScreenInfo');
 }
 
-function evalAssertText(text: string): string {
-  return `(function(){ var M = typeof __REACT_NATIVE_MCP__ !== 'undefined' ? __REACT_NATIVE_MCP__ : null; return M && M.assertText ? M.assertText(${JSON.stringify(text)}) : null; })();`;
-}
+// ─── 공유 상수 ───────────────────────────────────────────────────
+
+const ANDROID_KEYCODES: Record<string, number> = {
+  back: 4, home: 3, enter: 66, tab: 61, delete: 67,
+  up: 19, down: 20, left: 21, right: 22,
+};
+
+const VALID_DIRECTIONS = ['up', 'down', 'left', 'right'] as const;
 
 // ─── Shared helpers ──────────────────────────────────────────────
 
@@ -139,7 +146,7 @@ async function resolveElementCoords(
 
   if (filterUid) {
     const all = (await ws.eval(
-      evalQuerySelectorAll(selector),
+      buildQuerySelectorAllEvalCode(selector),
       device.deviceId,
       device.platform
     )) as Record<string, unknown>[];
@@ -147,7 +154,7 @@ async function resolveElementCoords(
     if (match) result = match;
   } else {
     result = (await ws.eval(
-      evalQuerySelector(selector),
+      buildQuerySelectorEvalCode(selector),
       device.deviceId,
       device.platform
     )) as Record<string, unknown> | null;
@@ -208,6 +215,18 @@ async function getIOSOrientation(
   }
 
   return { graphicsOrientation, width, height };
+}
+
+/** 요소 정보를 compact 한 줄 포맷으로 변환 */
+function formatElementLine(el: Record<string, unknown>): string {
+  const parts = [String(el.type ?? 'element')];
+  if (el.testID) parts.push(`#${el.testID}`);
+  if (el.uid && el.uid !== el.testID) parts.push(`uid=${el.uid}`);
+  if (el.pageX != null) parts.push(`pageX=${Math.round(Number(el.pageX))}`);
+  if (el.pageY != null) parts.push(`pageY=${Math.round(Number(el.pageY))}`);
+  if (el.width != null) parts.push(`w=${Math.round(Number(el.width))}`);
+  if (el.height != null) parts.push(`h=${Math.round(Number(el.height))}`);
+  return parts.join(' ');
 }
 
 // ─── Commands ────────────────────────────────────────────────────
@@ -332,9 +351,12 @@ export async function cmdTap(
     // UI 업데이트 대기
     await new Promise((r) => setTimeout(r, 300));
 
-    const label = target.startsWith('@e')
-      ? `${target} ${loadSession()?.refs[target]?.type ?? ''}${loadSession()?.refs[target]?.testID ? ' #' + loadSession()?.refs[target]?.testID : ''}`
-      : target;
+    let label = target;
+    if (target.startsWith('@e')) {
+      const s = loadSession();
+      const r = s?.refs[target];
+      label = `${target} ${r?.type ?? ''}${r?.testID ? ' #' + r.testID : ''}`;
+    }
     console.log(`✓ ${isLongPress ? 'long-pressed' : 'tapped'} ${label.trim()}`);
   } finally {
     ws.close();
@@ -386,9 +408,13 @@ export async function cmdAssert(
       case 'text': {
         const text = args[0];
         if (!text) throw new Error('Usage: rn-mcp assert text <text>');
-        // Fiber 트리에서 텍스트 검색
-        const tree = await ws.eval(evalGetComponentTree(30), device.deviceId, device.platform);
-        const found = tree ? JSON.stringify(tree).includes(text) : false;
+        // :text() 셀렉터로 정확한 텍스트 검색 (JSON.stringify false-positive 방지)
+        const result = await ws.eval(
+          buildQuerySelectorEvalCode(`:text(${JSON.stringify(text)})`),
+          device.deviceId,
+          device.platform
+        );
+        const found = result != null;
         if (found) {
           console.log(`✓ text "${text}" found`);
         } else {
@@ -428,7 +454,7 @@ export async function cmdAssert(
           throw new Error('Usage: rn-mcp assert count <selector> <n>');
         }
         const list = (await ws.eval(
-          evalQuerySelectorAll(selector),
+          buildQuerySelectorAllEvalCode(selector),
           device.deviceId,
           device.platform
         )) as unknown[];
@@ -464,7 +490,7 @@ export async function cmdQuery(
   try {
     if (opts.all) {
       const list = (await ws.eval(
-        evalQuerySelectorAll(selector),
+        buildQuerySelectorAllEvalCode(selector),
         device.deviceId,
         device.platform
       )) as Record<string, unknown>[];
@@ -478,19 +504,12 @@ export async function cmdQuery(
       } else {
         console.log(`# ${list.length} matches`);
         for (const el of list) {
-          const parts = [String(el.type ?? 'element')];
-          if (el.testID) parts.push(`#${el.testID}`);
-          if (el.uid && el.uid !== el.testID) parts.push(`uid=${el.uid}`);
-          if (el.pageX != null) parts.push(`pageX=${Math.round(Number(el.pageX))}`);
-          if (el.pageY != null) parts.push(`pageY=${Math.round(Number(el.pageY))}`);
-          if (el.width != null) parts.push(`w=${Math.round(Number(el.width))}`);
-          if (el.height != null) parts.push(`h=${Math.round(Number(el.height))}`);
-          console.log(`- ${parts.join(' ')}`);
+          console.log(`- ${formatElementLine(el)}`);
         }
       }
     } else {
       const result = (await ws.eval(
-        evalQuerySelector(selector),
+        buildQuerySelectorEvalCode(selector),
         device.deviceId,
         device.platform
       )) as Record<string, unknown> | null;
@@ -502,14 +521,7 @@ export async function cmdQuery(
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
       } else {
-        const parts = [String(result.type ?? 'element')];
-        if (result.testID) parts.push(`#${result.testID}`);
-        if (result.uid && result.uid !== result.testID) parts.push(`uid=${result.uid}`);
-        if (result.pageX != null) parts.push(`pageX=${Math.round(Number(result.pageX))}`);
-        if (result.pageY != null) parts.push(`pageY=${Math.round(Number(result.pageY))}`);
-        if (result.width != null) parts.push(`w=${Math.round(Number(result.width))}`);
-        if (result.height != null) parts.push(`h=${Math.round(Number(result.height))}`);
-        console.log(parts.join(' '));
+        console.log(formatElementLine(result));
       }
     }
   } finally {
@@ -525,9 +537,8 @@ export async function cmdSwipe(
   direction: string,
   opts: CliOptions & { dist?: number }
 ): Promise<void> {
-  const validDirs = ['up', 'down', 'left', 'right'];
-  if (!validDirs.includes(direction)) {
-    throw new Error(`Invalid direction: ${direction}. Use: ${validDirs.join(', ')}`);
+  if (!VALID_DIRECTIONS.includes(direction as any)) {
+    throw new Error(`Invalid direction: ${direction}. Use: ${VALID_DIRECTIONS.join(', ')}`);
   }
 
   const { ws, device } = await connectAndResolveDevice(opts);
@@ -597,14 +608,10 @@ export async function cmdKey(button: string, opts: CliOptions): Promise<void> {
     } else {
       if (!(await checkAdbAvailable())) throw new Error('adb not installed');
       const serial = await resolveSerial(device.deviceId);
-      const keycodeMap: Record<string, number> = {
-        back: 4, home: 3, enter: 66, tab: 61, delete: 67,
-        up: 19, down: 20, left: 21, right: 22,
-      };
-      const keycode = keycodeMap[button.toLowerCase()];
+      const keycode = ANDROID_KEYCODES[button.toLowerCase()];
       if (keycode == null) {
         throw new Error(
-          `Unknown key: ${button}. Available: ${Object.keys(keycodeMap).join(', ')}`
+          `Unknown key: ${button}. Available: ${Object.keys(ANDROID_KEYCODES).join(', ')}`
         );
       }
       await runAdbCommand(['shell', 'input', 'keyevent', String(keycode)], serial, {
@@ -637,11 +644,6 @@ export async function cmdScreenshot(
       if (!(await checkAdbAvailable())) throw new Error('adb not installed');
       const serial = await resolveSerial(device.deviceId);
       const outFile = opts.output ?? 'screenshot.png';
-      await runAdbCommand(['exec-out', 'screencap', '-p'], serial, { timeoutMs: opts.timeout });
-      // screencap binary output → file
-      const { execFile: execFileCb } = await import('node:child_process');
-      const { writeFileSync } = await import('node:fs');
-      const { runCommand } = await import('../tools/run-command.js');
       const buf = await runCommand(
         'adb',
         [...(serial ? ['-s', serial] : []), 'exec-out', 'screencap', '-p'],
@@ -680,9 +682,14 @@ export async function cmdInitAgent(
   for (const { file, label } of targets) {
     const filePath = path.resolve(process.cwd(), file);
 
-    if (existsSync(filePath)) {
-      const content = readFileSync(filePath, 'utf8');
+    let content: string | null = null;
+    try {
+      content = readFileSync(filePath, 'utf8');
+    } catch {
+      // 파일 없음
+    }
 
+    if (content != null) {
       // 이미 가이드가 있으면 교체
       if (content.includes(MARKER_START)) {
         const regex = new RegExp(

--- a/packages/react-native-mcp-server/src/cli/commands.ts
+++ b/packages/react-native-mcp-server/src/cli/commands.ts
@@ -539,7 +539,7 @@ export async function cmdQuery(
 }
 
 /**
- * rn-mcp swipe <@ref|selector> <direction> [--dist <px>]
+ * rn-mcp swipe <@ref|selector> <direction> [--dist <dp>]
  */
 export async function cmdSwipe(
   target: string,

--- a/packages/react-native-mcp-server/src/cli/commands.ts
+++ b/packages/react-native-mcp-server/src/cli/commands.ts
@@ -321,7 +321,7 @@ export async function cmdTap(target: string, opts: CliOptions & { long?: number 
           'idb not installed. Run: brew tap facebook/fb && brew install idb-companion'
         );
       }
-      const udid = await resolveUdid(device.deviceId);
+      const udid = await resolveUdid();
       const orientInfo = await getIOSOrientation(ws, device, udid);
       const t = transformForIdb(cx, cy, orientInfo);
       const ix = Math.round(t.x);
@@ -333,7 +333,7 @@ export async function cmdTap(target: string, opts: CliOptions & { long?: number 
       if (!(await checkAdbAvailable())) {
         throw new Error('adb not installed. Run: brew install android-platform-tools');
       }
-      const serial = await resolveSerial(device.deviceId);
+      const serial = await resolveSerial();
       const scale = await getAndroidScale(serial);
       const topInsetPx = await getAndroidTopInset(serial);
       const topInsetDp = topInsetPx / scale;
@@ -589,7 +589,7 @@ export async function cmdSwipe(
   try {
     if (device.platform === 'ios') {
       if (!(await checkIdbAvailable())) throw new Error('idb not installed');
-      const udid = await resolveUdid(device.deviceId);
+      const udid = await resolveUdid();
       const orientInfo = await getIOSOrientation(ws, device, udid);
       const t1 = transformForIdb(x1, y1, orientInfo);
       const t2 = transformForIdb(x2, y2, orientInfo);
@@ -607,7 +607,7 @@ export async function cmdSwipe(
       );
     } else {
       if (!(await checkAdbAvailable())) throw new Error('adb not installed');
-      const serial = await resolveSerial(device.deviceId);
+      const serial = await resolveSerial();
       const scale = await getAndroidScale(serial);
       const topInsetPx = await getAndroidTopInset(serial);
       const topInsetDp = topInsetPx / scale;
@@ -638,12 +638,12 @@ export async function cmdKey(button: string, opts: CliOptions): Promise<void> {
   try {
     if (device.platform === 'ios') {
       if (!(await checkIdbAvailable())) throw new Error('idb not installed');
-      const udid = await resolveUdid(device.deviceId);
+      const udid = await resolveUdid();
       const idbButton = button === 'back' ? 'HOME' : button.toUpperCase();
       await runIdbCommand(['ui', 'button', idbButton], udid, { timeoutMs: opts.timeout });
     } else {
       if (!(await checkAdbAvailable())) throw new Error('adb not installed');
-      const serial = await resolveSerial(device.deviceId);
+      const serial = await resolveSerial();
       const keycode = ANDROID_KEYCODES[button.toLowerCase()];
       if (keycode == null) {
         throw new Error(
@@ -670,13 +670,13 @@ export async function cmdScreenshot(opts: CliOptions & { output?: string }): Pro
   try {
     if (device.platform === 'ios') {
       if (!(await checkIdbAvailable())) throw new Error('idb not installed');
-      const udid = await resolveUdid(device.deviceId);
+      const udid = await resolveUdid();
       const outFile = opts.output ?? 'screenshot.png';
       await runIdbCommand(['screenshot', '--path', outFile], udid, { timeoutMs: opts.timeout });
       console.log(`✓ saved ${outFile}`);
     } else {
       if (!(await checkAdbAvailable())) throw new Error('adb not installed');
-      const serial = await resolveSerial(device.deviceId);
+      const serial = await resolveSerial();
       const outFile = opts.output ?? 'screenshot.png';
       const buf = await runCommand(
         'adb',

--- a/packages/react-native-mcp-server/src/cli/ref-map.ts
+++ b/packages/react-native-mcp-server/src/cli/ref-map.ts
@@ -1,0 +1,89 @@
+/**
+ * Snapshot 트리에 @e1, @e2, ... refs 할당.
+ * depth-first 순회로 순번 부여.
+ */
+
+import type { RefInfo } from './session.js';
+
+interface SnapshotNode {
+  uid?: string;
+  type?: string;
+  testID?: string;
+  text?: string;
+  children?: SnapshotNode[];
+}
+
+const INTERACTIVE_TYPES = new Set([
+  'TouchableOpacity',
+  'TouchableHighlight',
+  'TouchableWithoutFeedback',
+  'TouchableNativeFeedback',
+  'Pressable',
+  'Button',
+  'TextInput',
+  'Switch',
+  'Slider',
+  'Picker',
+  'CheckBox',
+]);
+
+export interface AssignResult {
+  refs: Record<string, RefInfo>;
+  lines: string[];
+}
+
+/**
+ * Fiber 트리를 순회하며 각 요소에 @e1, @e2, ... 할당.
+ * interactive=true이면 인터랙티브 요소만 포함.
+ */
+export function assignRefs(root: SnapshotNode, interactive: boolean): AssignResult {
+  const refs: Record<string, RefInfo> = {};
+  const lines: string[] = [];
+  let counter = 1;
+
+  function walk(node: SnapshotNode, depth: number): void {
+    const type = node.type ?? '';
+    const uid = node.uid ?? '';
+    const testID = node.testID ?? '';
+    const text = node.text ?? '';
+    const isInteractive = INTERACTIVE_TYPES.has(type);
+
+    // interactive 모드: 인터랙티브가 아닌 노드는 자식만 순회
+    if (interactive && !isInteractive && depth > 0) {
+      for (const child of node.children ?? []) {
+        walk(child, depth);
+      }
+      return;
+    }
+
+    // 의미 없는 노드 스킵 (타입만 있고 testID/text 없는 비인터랙티브 노드)
+    const hasMeaningfulInfo = testID || text || isInteractive || depth === 0;
+    if (!hasMeaningfulInfo && depth > 0) {
+      for (const child of node.children ?? []) {
+        walk(child, depth + 1);
+      }
+      return;
+    }
+
+    const ref = `@e${counter++}`;
+    refs[ref] = {
+      uid,
+      type,
+      ...(testID ? { testID } : {}),
+      ...(text ? { text } : {}),
+    };
+
+    const indent = '  '.repeat(depth);
+    const parts: string[] = [type];
+    if (testID) parts.push(`#${testID}`);
+    if (text) parts.push(`"${text}"`);
+    lines.push(`${ref.padEnd(6)} ${indent}${parts.join(' ')}`);
+
+    for (const child of node.children ?? []) {
+      walk(child, depth + 1);
+    }
+  }
+
+  walk(root, 0);
+  return { refs, lines };
+}

--- a/packages/react-native-mcp-server/src/cli/ref-map.ts
+++ b/packages/react-native-mcp-server/src/cli/ref-map.ts
@@ -4,6 +4,7 @@
  */
 
 import type { RefInfo } from './session.js';
+import { INTERACTIVE_TYPES } from '../shared/interactive-types.js';
 
 interface SnapshotNode {
   uid?: string;
@@ -12,20 +13,6 @@ interface SnapshotNode {
   text?: string;
   children?: SnapshotNode[];
 }
-
-const INTERACTIVE_TYPES = new Set([
-  'TouchableOpacity',
-  'TouchableHighlight',
-  'TouchableWithoutFeedback',
-  'TouchableNativeFeedback',
-  'Pressable',
-  'Button',
-  'TextInput',
-  'Switch',
-  'Slider',
-  'Picker',
-  'CheckBox',
-]);
 
 export interface AssignResult {
   refs: Record<string, RefInfo>;

--- a/packages/react-native-mcp-server/src/cli/session.ts
+++ b/packages/react-native-mcp-server/src/cli/session.ts
@@ -1,0 +1,52 @@
+/**
+ * CLI 세션 파일 관리.
+ * ~/.rn-mcp/session.json에 refs 매핑과 디바이스 정보 저장.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+export interface RefInfo {
+  uid: string;
+  type: string;
+  testID?: string;
+  text?: string;
+}
+
+export interface Session {
+  port: number;
+  deviceId?: string;
+  platform?: string;
+  refs: Record<string, RefInfo>;
+  updatedAt: string;
+}
+
+const SESSION_DIR = path.join(homedir(), '.rn-mcp');
+const SESSION_FILE = path.join(SESSION_DIR, 'session.json');
+
+export function loadSession(): Session | null {
+  try {
+    const data = readFileSync(SESSION_FILE, 'utf8');
+    return JSON.parse(data) as Session;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSession(session: Session): void {
+  mkdirSync(SESSION_DIR, { recursive: true });
+  session.updatedAt = new Date().toISOString();
+  writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+}
+
+/**
+ * @ref → RefInfo 해석. 없으면 에러.
+ */
+export function resolveRef(session: Session, ref: string): RefInfo {
+  const info = session.refs[ref];
+  if (!info) {
+    throw new Error(`${ref} not found. Run \`rn-mcp snapshot -i\` to refresh refs.`);
+  }
+  return info;
+}

--- a/packages/react-native-mcp-server/src/cli/ws-client.ts
+++ b/packages/react-native-mcp-server/src/cli/ws-client.ts
@@ -1,0 +1,143 @@
+/**
+ * CLI용 WebSocket 클라이언트.
+ * 기존 MCP 서버의 WebSocket 서버에 extension client로 연결.
+ */
+
+import WebSocket from 'ws';
+
+export interface DeviceInfo {
+  deviceId: string;
+  platform: string;
+  deviceName: string | null;
+  connected: boolean;
+  topInsetDp: number;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+}
+
+export class WsClient {
+  private ws: WebSocket;
+  private pending = new Map<string, PendingRequest>();
+  private _devices: DeviceInfo[] = [];
+
+  private constructor(ws: WebSocket, devices: DeviceInfo[]) {
+    this.ws = ws;
+    this._devices = devices;
+  }
+
+  /**
+   * WebSocket 서버에 extension client로 연결.
+   * MCP 서버가 실행 중이어야 함 (포트 12300 기본).
+   */
+  static async connect(port: number = 12300, timeoutMs: number = 5000): Promise<WsClient> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.close();
+        reject(
+          new Error(
+            `Connection timeout (port ${port}). Is the MCP server running?\n` +
+              'Start it with: react-native-mcp-server (via MCP client or directly)'
+          )
+        );
+      }, timeoutMs);
+
+      const ws = new WebSocket(`ws://localhost:${port}`);
+
+      ws.on('open', () => {
+        ws.send(JSON.stringify({ type: 'extension-init' }));
+      });
+
+      ws.on('message', (data) => {
+        try {
+          const msg = JSON.parse(data.toString());
+          if (msg.type === 'extension-init-ack') {
+            clearTimeout(timer);
+            const client = new WsClient(ws, msg.devices ?? []);
+            ws.removeAllListeners('message');
+            ws.on('message', (d) => client.handleMessage(d));
+            resolve(client);
+          }
+        } catch {
+          // ignore malformed
+        }
+      });
+
+      ws.on('error', (err) => {
+        clearTimeout(timer);
+        reject(
+          new Error(
+            `Cannot connect to ws://localhost:${port}.\n` +
+              'Make sure the MCP server is running (started by your editor or manually).\n' +
+              `Error: ${err.message}`
+          )
+        );
+      });
+    });
+  }
+
+  private handleMessage(data: WebSocket.RawData): void {
+    try {
+      const msg = JSON.parse(data.toString()) as {
+        id?: string;
+        result?: unknown;
+        error?: string;
+      };
+      if (msg.id && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id)!;
+        this.pending.delete(msg.id);
+        if (msg.error) {
+          reject(new Error(msg.error));
+        } else {
+          resolve(msg.result);
+        }
+      }
+    } catch {
+      // ignore malformed
+    }
+  }
+
+  /**
+   * 앱 런타임에서 JavaScript 코드 실행.
+   */
+  async eval(code: string, deviceId?: string, platform?: string, timeoutMs = 10000): Promise<unknown> {
+    const id = crypto.randomUUID();
+    const params: Record<string, unknown> = { code };
+    if (deviceId) params.deviceId = deviceId;
+    if (platform) params.platform = platform;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error('Request timed out: no response from app'));
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: (val) => {
+          clearTimeout(timer);
+          resolve(val);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+
+      this.ws.send(JSON.stringify({ method: 'eval', id, params }));
+    });
+  }
+
+  get devices(): DeviceInfo[] {
+    return this._devices;
+  }
+
+  close(): void {
+    for (const { reject } of this.pending.values()) {
+      reject(new Error('Client closed'));
+    }
+    this.pending.clear();
+    this.ws.close();
+  }
+}

--- a/packages/react-native-mcp-server/src/cli/ws-client.ts
+++ b/packages/react-native-mcp-server/src/cli/ws-client.ts
@@ -103,7 +103,12 @@ export class WsClient {
   /**
    * 앱 런타임에서 JavaScript 코드 실행.
    */
-  async eval(code: string, deviceId?: string, platform?: string, timeoutMs = 10000): Promise<unknown> {
+  async eval(
+    code: string,
+    deviceId?: string,
+    platform?: string,
+    timeoutMs = 10000
+  ): Promise<unknown> {
     const id = crypto.randomUUID();
     const params: Record<string, unknown> = { code };
     if (deviceId) params.deviceId = deviceId;

--- a/packages/react-native-mcp-server/src/cli/ws-client.ts
+++ b/packages/react-native-mcp-server/src/cli/ws-client.ts
@@ -58,6 +58,7 @@ export class WsClient {
             const client = new WsClient(ws, msg.devices ?? []);
             ws.removeAllListeners('message');
             ws.on('message', (d) => client.handleMessage(d));
+            ws.on('close', () => client.onDisconnect());
             resolve(client);
           }
         } catch {
@@ -127,6 +128,14 @@ export class WsClient {
 
       this.ws.send(JSON.stringify({ method: 'eval', id, params }));
     });
+  }
+
+  /** WebSocket 예기치 않은 종료 시 대기 중인 요청 전부 reject */
+  private onDisconnect(): void {
+    for (const { reject } of this.pending.values()) {
+      reject(new Error('WebSocket connection closed unexpectedly'));
+    }
+    this.pending.clear();
   }
 
   get devices(): DeviceInfo[] {

--- a/packages/react-native-mcp-server/src/shared/interactive-types.ts
+++ b/packages/react-native-mcp-server/src/shared/interactive-types.ts
@@ -1,0 +1,14 @@
+/** 인터랙티브 컴포넌트 타입 (snapshot interactive 필터, CLI ref-map 공유) */
+export const INTERACTIVE_TYPES = new Set([
+  'TouchableOpacity',
+  'TouchableHighlight',
+  'TouchableWithoutFeedback',
+  'TouchableNativeFeedback',
+  'Pressable',
+  'Button',
+  'TextInput',
+  'Switch',
+  'Slider',
+  'Picker',
+  'CheckBox',
+]);

--- a/packages/react-native-mcp-server/src/tools/take-snapshot.ts
+++ b/packages/react-native-mcp-server/src/tools/take-snapshot.ts
@@ -23,20 +23,7 @@ const schema = z.object({
   platform: platformParam,
 });
 
-/** 인터랙티브 컴포넌트 타입 */
-const INTERACTIVE_TYPES = new Set([
-  'TouchableOpacity',
-  'TouchableHighlight',
-  'TouchableWithoutFeedback',
-  'TouchableNativeFeedback',
-  'Pressable',
-  'Button',
-  'TextInput',
-  'Switch',
-  'Slider',
-  'Picker',
-  'CheckBox',
-]);
+import { INTERACTIVE_TYPES } from '../shared/interactive-types.js';
 
 interface SnapshotNode {
   uid?: string;

--- a/packages/react-native-mcp-server/tsdown.config.ts
+++ b/packages/react-native-mcp-server/tsdown.config.ts
@@ -22,6 +22,7 @@ export default defineConfig([
     name: 'server',
     entry: {
       index: './src/index.ts',
+      cli: './src/cli.ts',
       symbolicate: './src/symbolicate.ts',
       'transformer-entry': './src/transformer-entry.ts',
       'client/index': './src/client/index.ts',


### PR DESCRIPTION
## Summary

- agent-browser 스타일의 **Snapshot + Refs 패턴**을 React Native에 적용한 CLI 도구 (`rn-mcp`)
- AI 에이전트(Claude Code, Codex 등)가 셸에서 직접 앱을 제어 — MCP 도구 대비 토큰 50~70% 절감
- `init-agent` 명령으로 AGENTS.md/CLAUDE.md에 CLI 가이드 자동 추가 (한영 지원)

### 주요 명령어

```bash
rn-mcp snapshot -i           # interactive 요소를 @e1, @e2 refs로 반환
rn-mcp tap @e3               # ref로 탭 (좌표 자동 변환)
rn-mcp type @e5 "텍스트"      # TextInput에 입력
rn-mcp assert text "..."     # 텍스트 검증 (exit 0/1)
rn-mcp init-agent --lang ko  # AGENTS.md/CLAUDE.md 가이드 추가
```

### 아키텍처

- WebSocket extension client로 기존 MCP 서버에 연결 (별도 서버 불필요)
- `~/.rn-mcp/session.json`에 refs 매핑 저장 (CLI 호출 간 상태 공유)
- idb/adb 직접 실행 (기존 유틸 재사용)
- `bin: rn-mcp → dist/cli.js` (기존 패키지에 entry point 추가)

### 파일 구조

| 파일 | 역할 |
|------|------|
| `src/cli.ts` | CLI entry point + --help + 라우팅 |
| `src/cli/ws-client.ts` | WebSocket extension client |
| `src/cli/session.ts` | `~/.rn-mcp/session.json` 세션 관리 |
| `src/cli/ref-map.ts` | Snapshot → @ref 할당 |
| `src/cli/commands.ts` | 명령어 구현 (status, snapshot, tap, type, assert, query, swipe, key, screenshot, init-agent) |
| `src/cli/agent-guide.ts` | AGENTS.md/CLAUDE.md 가이드 텍스트 (한영) |
| `src/shared/interactive-types.ts` | INTERACTIVE_TYPES 공유 상수 (take-snapshot + ref-map) |
| `docs/cli-spec.md` | CLI 설계 스펙 문서 |

### CI 변경

- `test.yml`: CLI smoke test + init-agent 통합 테스트 추가
- `e2e-ios.yml`: YAML E2E 후 CLI smoke test 실행
- `e2e-android.yml`: YAML E2E 후 CLI smoke test 실행 + adb PATH 설정 + libgl1-mesa-dri 삭제 제거
- `cli-smoke.sh`: 10단계 CLI 통합 테스트 (status, snapshot, tap, assert, query, init-agent)

### 코드 리뷰 반영 (/simplify)

- eval 코드 빌더 중복 제거 → `buildQuerySelectorEvalCode` 등 기존 export 재사용
- `INTERACTIVE_TYPES` 중복 → `shared/interactive-types.ts`로 추출
- `assert text` false-positive 수정 → `:text()` 셀렉터 기반
- `loadSession()` 3회 호출 → 1회로
- Android screencap 이중 실행 제거
- WebSocket close 핸들러 추가
- 죽은 코드/import 제거

## Test plan

- [x] 유닛 테스트 24개 (ref-map, session, agent-guide, CLI help)
- [x] CI smoke test (--help, --version, init-agent)
- [x] E2E iOS — CLI smoke test 10단계 통과
- [x] E2E Android — CLI smoke test 10단계 통과
- [x] 린트 (oxlint + oxfmt) 통과
- [x] 전체 CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)